### PR TITLE
Fix error 1.21.1

### DIFF
--- a/src/main/java/me/elaineqheart/auctionHouse/data/ram/ItemManager.java
+++ b/src/main/java/me/elaineqheart/auctionHouse/data/ram/ItemManager.java
@@ -649,24 +649,8 @@ public class ItemManager {
     }
     public static boolean isBundle(ItemStack item) {
         if (item == null) return false;
-        Material type = item.getType();
-        return type == Material.BUNDLE ||
-                type == Material.BLACK_BUNDLE ||
-                type == Material.BLUE_BUNDLE ||
-                type == Material.BROWN_BUNDLE ||
-                type == Material.CYAN_BUNDLE ||
-                type == Material.GRAY_BUNDLE ||
-                type == Material.GREEN_BUNDLE ||
-                type == Material.LIGHT_BLUE_BUNDLE ||
-                type == Material.LIGHT_GRAY_BUNDLE ||
-                type == Material.LIME_BUNDLE ||
-                type == Material.MAGENTA_BUNDLE ||
-                type == Material.ORANGE_BUNDLE ||
-                type == Material.PINK_BUNDLE ||
-                type == Material.PURPLE_BUNDLE ||
-                type == Material.RED_BUNDLE ||
-                type == Material.WHITE_BUNDLE ||
-                type == Material.YELLOW_BUNDLE;
+        // Colored bundles (BLACK_BUNDLE, etc.) were added in 1.21.2; use name matching for cross-version support.
+        return item.getType().name().endsWith("_BUNDLE");
     }
 
 }


### PR DESCRIPTION
[11:53:00 ERROR]: Could not pass event InventoryClickEvent to AuctionHouse v1.4.7 java.lang.NoSuchFieldError: Class org.bukkit.Material does not have member field 'org.bukkit.Material BLACK_BUNDLE'
        at AuctionHouse-1.4.7.jar/me.elaineqheart.auctionHouse.data.ram.ItemManager.isBundle(ItemManager.java:653) ~[AuctionHouse-1.4.7.jar:?]
        at AuctionHouse-1.4.7.jar/me.elaineqheart.auctionHouse.GUI.impl.AuctionHouseGUI.lambda$auctionItem$1(AuctionHouseGUI.java:132) ~[AuctionHouse-1.4.7.jar:?]
        at AuctionHouse-1.4.7.jar/me.elaineqheart.auctionHouse.GUI.InventoryGUI.onClick(InventoryGUI.java:51) ~[AuctionHouse-1.4.7.jar:?]
        at AuctionHouse-1.4.7.jar/me.elaineqheart.auctionHouse.GUI.GUIManager.handleClick(GUIManager.java:38) ~[AuctionHouse-1.4.7.jar:?]
        at AuctionHouse-1.4.7.jar/me.elaineqheart.auctionHouse.GUI.GUIListener.onClick(GUIListener.java:19) ~[AuctionHouse-1.4.7.jar:?]
        at com.destroystokyo.paper.event.executor.asm.generated.GeneratedEventExecutor1238.execute(Unknown Source) ~[?:?]
        at org.bukkit.plugin.EventExecutor$2.execute(EventExecutor.java:77) ~[paper-mojangapi-1.21.1-R0.1-SNAPSHOT.jar:?]
        at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80) ~[paper-mojangapi-1.21.1-R0.1-SNAPSHOT.jar:1.21.1-2329-803bf62]
        at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[paper-mojangapi-1.21.1-R0.1-SNAPSHOT.jar:?]
        at io.papermc.paper.plugin.manager.PaperEventManager.callEvent(PaperEventManager.java:54) ~[purpur-1.21.1.jar:1.21.1-2329-803bf62]
        at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.callEvent(PaperPluginManagerImpl.java:131) ~[purpur-1.21.1.jar:1.21.1-2329-803bf62]
        at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:630) ~[paper-mojangapi-1.21.1-R0.1-SNAPSHOT.jar:?]
        at net.minecraft.server.network.ServerGamePacketListenerImpl.handleContainerClick(ServerGamePacketListenerImpl.java:3306) ~[purpur-1.21.1.jar:1.21.1-2329-803bf62]
        at net.minecraft.network.protocol.game.ServerboundContainerClickPacket.handle(ServerboundContainerClickPacket.java:69) ~[purpur-1.21.1.jar:1.21.1-2329-803bf62]
        at net.minecraft.network.protocol.game.ServerboundContainerClickPacket.handle(ServerboundContainerClickPacket.java:33) ~[purpur-1.21.1.jar:1.21.1-2329-803bf62]
        at net.minecraft.network.protocol.PacketUtils.lambda$ensureRunningOnSameThread$0(PacketUtils.java:56) ~[purpur-1.21.1.jar:1.21.1-2329-803bf62]
        at net.minecraft.server.TickTask.run(TickTask.java:18) ~[purpur-1.21.1.jar:1.21.1-2329-803bf62]
        at net.minecraft.util.thread.BlockableEventLoop.doRunTask(BlockableEventLoop.java:151) ~[purpur-1.21.1.jar:1.21.1-2329-803bf62]
        at net.minecraft.util.thread.ReentrantBlockableEventLoop.doRunTask(ReentrantBlockableEventLoop.java:24) ~[purpur-1.21.1.jar:1.21.1-2329-803bf62]
        at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:1581) ~[purpur-1.21.1.jar:1.21.1-2329-803bf62]
        at net.minecraft.server.MinecraftServer.doRunTask(MinecraftServer.java:201) ~[purpur-1.21.1.jar:1.21.1-2329-803bf62]
        at net.minecraft.util.thread.BlockableEventLoop.pollTask(BlockableEventLoop.java:125) ~[purpur-1.21.1.jar:1.21.1-2329-803bf62]
        at net.minecraft.server.MinecraftServer.pollTaskInternal(MinecraftServer.java:1558) ~[purpur-1.21.1.jar:1.21.1-2329-803bf62]
        at net.minecraft.server.MinecraftServer.pollTask(MinecraftServer.java:1551) ~[purpur-1.21.1.jar:1.21.1-2329-803bf62]
        at net.minecraft.util.thread.BlockableEventLoop.managedBlock(BlockableEventLoop.java:135) ~[purpur-1.21.1.jar:1.21.1-2329-803bf62]
        at net.minecraft.server.MinecraftServer.managedBlock(MinecraftServer.java:1510) ~[purpur-1.21.1.jar:1.21.1-2329-803bf62]
        at net.minecraft.server.MinecraftServer.waitUntilNextTick(MinecraftServer.java:1517) ~[purpur-1.21.1.jar:1.21.1-2329-803bf62]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1362) ~[purpur-1.21.1.jar:1.21.1-2329-803bf62]
        at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:333) ~[purpur-1.21.1.jar:1.21.1-2329-803bf62]
        at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]