### PR TITLE
Migration to paper api and kyori adventure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,11 +20,15 @@ repositories {
     maven { url = "https://jitpack.io" }
     maven { url = "https://repo.extendedclip.com/content/repositories/placeholderapi/" }
     maven { url = "https://mvn-repo.arim.space/lesser-gpl3/" }
+    maven {
+        name = "papermc"
+        url = uri("https://repo.papermc.io/repository/maven-public/")
+    }
 }
 
 //alt + ins
 dependencies {
-    compileOnly("org.spigotmc:spigot-api:1.21.4-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT")
     compileOnly("com.github.MilkBowl:VaultAPI:1.7") {
         exclude group: "org.bukkit", module: "bukkit"
     }
@@ -45,7 +49,6 @@ tasks.named("shadowJar") {
     archiveVersion.set(version)
     relocate("net.kyori.adventure", "me.elaineqheart.auctionHouse.libs.adventure")
     relocate("space.arim.morepaperlib", "me.elaineqheart.auctionHouse.libs.morepaperlib")
-    destinationDirectory.set(file("/media/elaine/Boot/Elaine/programmieren/java/minecraft/MC_test_servers/1.21.5_paper/plugins"))
     //destinationDirectory.set(file("/media/elaine/Boot/Elaine/programmieren/java/minecraft/MC_test_servers/26.2_spigot/plugins"))
     //destinationDirectory.set(file("/media/elaine/Boot/Elaine/programmieren/java/minecraft/MC_test_servers/1.21.11_purpur/plugins"))
     mergeServiceFiles()

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "me.elaineqheart"
-version = "1.5.4"
+version = "2.0.0"
 
 repositories {
     mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -34,8 +34,10 @@ dependencies {
     }
     compileOnly("com.github.Unp1xelt:Locale-API:1.0")
     compileOnly("me.clip:placeholderapi:2.11.6")
-    implementation("net.kyori:adventure-text-minimessage:4.25.0")
-    implementation("net.kyori:adventure-text-serializer-legacy:4.25.0")
+    // adventure is provided by Paper at runtime
+    compileOnly("net.kyori:adventure-text-minimessage:4.25.0")
+    compileOnly("net.kyori:adventure-text-serializer-legacy:4.25.0")
+    compileOnly("net.kyori:adventure-text-serializer-plain:4.25.0")
     implementation("space.arim.morepaperlib:morepaperlib:0.5.2")
 }
 
@@ -47,7 +49,6 @@ tasks.named("shadowJar") {
     archiveBaseName.set(rootProject.name ?: "AuctionHouse")
     archiveClassifier.set("")
     archiveVersion.set(version)
-    relocate("net.kyori.adventure", "me.elaineqheart.auctionHouse.libs.adventure")
     relocate("space.arim.morepaperlib", "me.elaineqheart.auctionHouse.libs.morepaperlib")
     //destinationDirectory.set(file("/media/elaine/Boot/Elaine/programmieren/java/minecraft/MC_test_servers/26.2_spigot/plugins"))
     //destinationDirectory.set(file("/media/elaine/Boot/Elaine/programmieren/java/minecraft/MC_test_servers/1.21.11_purpur/plugins"))

--- a/src/main/java/me/elaineqheart/auctionHouse/GUI/impl/AdminConfirmGUI.java
+++ b/src/main/java/me/elaineqheart/auctionHouse/GUI/impl/AdminConfirmGUI.java
@@ -106,7 +106,7 @@ public class AdminConfirmGUI extends InventoryGUI{
                     p.closeInventory();
                     Sounds.experience(event);
                     Sounds.breakWood(event);
-                    p.sendMessage(M.getFormatted("chat.admin-expire-auction", "%reason%", reason));
+                        p.sendMessage(M.getFormatted("chat.admin-expire-auction", "reason", reason));
                 });
     }
     private InventoryButton confirmDeleteItem() {
@@ -144,7 +144,7 @@ public class AdminConfirmGUI extends InventoryGUI{
                     p.closeInventory();
                     Sounds.experience(event);
                     Sounds.breakWood(event);
-                    p.sendMessage(M.getFormatted("chat.admin-delete-auction","%reason%", reason));
+                    p.sendMessage(M.getFormatted("chat.admin-delete-auction", "reason", reason));
                 });
     }
     private InventoryButton cancel(){

--- a/src/main/java/me/elaineqheart/auctionHouse/GUI/impl/AuctionHouseGUI.java
+++ b/src/main/java/me/elaineqheart/auctionHouse/GUI/impl/AuctionHouseGUI.java
@@ -228,10 +228,10 @@ public class AuctionHouseGUI extends InventoryGUI implements Runnable {
         ItemStack item = ConfigManager.layout.getItem("n");
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        meta.setItemName(M.getFormatted("items.next-page.name"));
-        meta.setLore(M.getLoreList("items.next-page.lore",
-                "%page%", String.valueOf(c.getCurrentPage()+1),
-                "%pages%", String.valueOf(pages+1)));
+        meta.itemName(M.getFormatted("items.next-page.name"));
+        meta.lore(M.getLoreList("items.next-page.lore",
+                "page", String.valueOf(c.getCurrentPage()+1),
+                "pages", String.valueOf(pages+1)));
 
         item.setItemMeta(meta);
         return new InventoryButton()
@@ -248,10 +248,10 @@ public class AuctionHouseGUI extends InventoryGUI implements Runnable {
         ItemStack item = ConfigManager.layout.getItem("p");
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        meta.setItemName(M.getFormatted("items.previous-page.name"));
-        meta.setLore(M.getLoreList("items.previous-page.lore",
-                "%page%", String.valueOf(c.getCurrentPage()+1),
-                "%pages%", String.valueOf((pages+1))));
+        meta.itemName(M.getFormatted("items.previous-page.name"));
+        meta.lore(M.getLoreList("items.previous-page.lore",
+                "page", String.valueOf(c.getCurrentPage()+1),
+                "pages", String.valueOf((pages+1))));
         item.setItemMeta(meta);
         return new InventoryButton()
                 .creator(player -> item)
@@ -266,8 +266,8 @@ public class AuctionHouseGUI extends InventoryGUI implements Runnable {
         ItemStack item = c.getCurrentSearch().isEmpty() ? ConfigManager.layout.getItem("s") : ConfigManager.layout.getItem("active-search");
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        meta.setItemName(M.getFormatted("items.search.name"));
-        meta.setLore(M.getLoreList("items.search.lore", "%filter%", c.getCurrentSearch()));
+        meta.itemName(M.getFormatted("items.search.name"));
+        meta.lore(M.getLoreList("items.search.lore", "filter", c.getCurrentSearch()));
         item.setItemMeta(meta);
         return new InventoryButton()
                 .creator(player -> item)

--- a/src/main/java/me/elaineqheart/auctionHouse/GUI/impl/BundleViewGUI.java
+++ b/src/main/java/me/elaineqheart/auctionHouse/GUI/impl/BundleViewGUI.java
@@ -77,10 +77,10 @@ public class BundleViewGUI extends InventoryGUI {
         ItemStack item = ConfigManager.layout.getItem("n");
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        meta.setItemName(M.getFormatted("items.next-page.name"));
-        meta.setLore(M.getLoreList("items.next-page.lore",
-                "%page%", String.valueOf(page+1),
-                "%pages%", String.valueOf(2)));
+        meta.itemName(M.getFormatted("items.next-page.name"));
+        meta.lore(M.getLoreList("items.next-page.lore",
+                "page", String.valueOf(page+1),
+                "pages", String.valueOf(2)));
         item.setItemMeta(meta);
         return new InventoryButton()
                 .creator(player -> item)
@@ -95,10 +95,10 @@ public class BundleViewGUI extends InventoryGUI {
         ItemStack item = ConfigManager.layout.getItem("p");
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        meta.setItemName(M.getFormatted("items.previous-page.name"));
-        meta.setLore(M.getLoreList("items.previous-page.lore",
-                "%page%", String.valueOf(page+1),
-                "%pages%", String.valueOf(2)));
+        meta.itemName(M.getFormatted("items.previous-page.name"));
+        meta.lore(M.getLoreList("items.previous-page.lore",
+                "page", String.valueOf(page+1),
+                "pages", String.valueOf(2)));
         item.setItemMeta(meta);
         return new InventoryButton()
                 .creator(player -> item)

--- a/src/main/java/me/elaineqheart/auctionHouse/GUI/impl/CollectExpiredItemGUI.java
+++ b/src/main/java/me/elaineqheart/auctionHouse/GUI/impl/CollectExpiredItemGUI.java
@@ -107,11 +107,11 @@ public class CollectExpiredItemGUI extends InventoryGUI {
 
                     if(note.getAdminMessage() != null && !note.getAdminMessage().isEmpty()) { // expired by a moderator
                         if(note.getItem().equals(ItemManager.createDirt())) {
-                            p.sendMessage(M.getFormatted("chat.deleted-auction-by-admin", "%reason%", note.getAdminMessage()));
+                            p.sendMessage(M.getFormatted("chat.deleted-auction-by-admin", "reason", note.getAdminMessage()));
                             p.closeInventory();
                             Sounds.breakWood(event);
                         }else {
-                            p.sendMessage(M.getFormatted("chat.expired-auction-by-admin", "%reason%", note.getAdminMessage()));
+                            p.sendMessage(M.getFormatted("chat.expired-auction-by-admin", "reason", note.getAdminMessage()));
                             p.closeInventory();
                             p.getInventory().addItem(withdrawItem);
                             Sounds.experience(event);

--- a/src/main/java/me/elaineqheart/auctionHouse/GUI/impl/CollectSoldItemGUI.java
+++ b/src/main/java/me/elaineqheart/auctionHouse/GUI/impl/CollectSoldItemGUI.java
@@ -12,6 +12,7 @@ import me.elaineqheart.auctionHouse.data.ram.AuctionHouseStorage;
 import me.elaineqheart.auctionHouse.data.ram.ItemManager;
 import me.elaineqheart.auctionHouse.data.ram.ItemNote;
 import me.elaineqheart.auctionHouse.pluginDependencies.VaultHook;
+import net.kyori.adventure.text.Component;
 import net.milkbowl.vault.economy.Economy;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
@@ -94,9 +95,10 @@ public class CollectSoldItemGUI extends InventoryGUI {
                 .creator(player -> ItemManager.collectSoldItem(getProfit(price)))
                 .consumer(event -> {
                     Player p = (Player) event.getWhoClicked();
-                    String message = M.getFormatted("chat.collect-sold-auction", getProfit(price),
-                            "%amount%", String.valueOf(item.getAmount()),
-                            "%item%", note.getItemName());
+                    Component message = M.getFormatted("chat.collect-sold-auction",
+                            "price", getProfit(price),
+                            "amount", String.valueOf(item.getAmount()),
+                            "item", note.getItemName());
 
                     boolean success = collect(p, note.getNoteID(), item.getAmount(), price);
                     AuctionHouse.getGuiManager().openGUI(p, c, goBackTo);

--- a/src/main/java/me/elaineqheart/auctionHouse/GUI/impl/ConfirmBidGUI.java
+++ b/src/main/java/me/elaineqheart/auctionHouse/GUI/impl/ConfirmBidGUI.java
@@ -119,7 +119,7 @@ public class ConfirmBidGUI extends InventoryGUI {
                     p.sendMessage(M.getFormatted("chat.placed-bid", price,
                             "%item%", note.getItemName()));
                     if (c.shouldKeepOpen()) AuctionHouse.getGuiManager().openGUI(new AuctionViewGUI(note, c, 0, goBackToAuctionHouse ? AhConfiguration.View.AUCTION_HOUSE : AhConfiguration.View.MY_AUCTIONS), p);
-                    else instance.getScheduler().globalRegionalScheduler().run(p::closeInventory);
+                    else instance.getScheduler().globalRegionalScheduler().run(() -> p.closeInventory());
 
                     Set<UUID> bidders = note.getBidders();
                     bidders.remove(p.getUniqueId());

--- a/src/main/java/me/elaineqheart/auctionHouse/GUI/impl/ConfirmBidGUI.java
+++ b/src/main/java/me/elaineqheart/auctionHouse/GUI/impl/ConfirmBidGUI.java
@@ -8,8 +8,8 @@ import me.elaineqheart.auctionHouse.data.persistentStorage.ItemNoteStorage;
 import me.elaineqheart.auctionHouse.data.persistentStorage.local.configs.M;
 import me.elaineqheart.auctionHouse.data.ram.*;
 import me.elaineqheart.auctionHouse.pluginDependencies.VaultHook;
-import net.md_5.bungee.api.chat.ClickEvent;
-import net.md_5.bungee.api.chat.TextComponent;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.ClickEvent;
 import net.milkbowl.vault.economy.Economy;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -116,8 +116,9 @@ public class ConfirmBidGUI extends InventoryGUI {
 
                     eco.withdrawPlayer(p, increase);
                     Sounds.experience(event);
-                    p.sendMessage(M.getFormatted("chat.placed-bid", price,
-                            "%item%", note.getItemName()));
+                    p.sendMessage(M.getFormatted("chat.placed-bid",
+                            "price", price,
+                            "item", note.getItemName()));
                     if (c.shouldKeepOpen()) AuctionHouse.getGuiManager().openGUI(new AuctionViewGUI(note, c, 0, goBackToAuctionHouse ? AhConfiguration.View.AUCTION_HOUSE : AhConfiguration.View.MY_AUCTIONS), p);
                     else instance.getScheduler().globalRegionalScheduler().run(() -> p.closeInventory());
 
@@ -127,12 +128,13 @@ public class ConfirmBidGUI extends InventoryGUI {
                         Player bidder = Bukkit.getPlayer(id);
                         if(bidder == null) continue;
                         double difference = price - note.getBid(bidder);
-                        bidder.sendMessage(M.getFormatted("chat.outbid.prefix", difference,
-                                "%player%", M.formatPlayer(p.getDisplayName(), p.getUniqueId()),
-                                "%item%", note.getItemName()));
-                        TextComponent click = new TextComponent(M.getFormatted("chat.outbid.interaction"));
-                        click.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/ah view " + note.getNoteID().toString()));
-                        bidder.spigot().sendMessage(click);
+                        bidder.sendMessage(M.getFormatted("chat.outbid.prefix",
+                                "price", difference,
+                                "player", M.formatPlayer(p.getDisplayName(), p.getUniqueId()),
+                                "item", note.getItemName()));
+                        Component click = M.getFormatted("chat.outbid.interaction")
+                                .clickEvent(ClickEvent.runCommand("/ah view " + note.getNoteID()));
+                        bidder.sendMessage(click);
                         if(AuctionViewGUI.currentGUIs.get(bidder) == null) continue;
                         AuctionViewGUI.currentGUIs.get(bidder).update();
                     }

--- a/src/main/java/me/elaineqheart/auctionHouse/GUI/impl/ConfirmBuyGUI.java
+++ b/src/main/java/me/elaineqheart/auctionHouse/GUI/impl/ConfirmBuyGUI.java
@@ -12,8 +12,8 @@ import me.elaineqheart.auctionHouse.data.ram.AuctionHouseStorage;
 import me.elaineqheart.auctionHouse.data.ram.ItemManager;
 import me.elaineqheart.auctionHouse.data.ram.ItemNote;
 import me.elaineqheart.auctionHouse.pluginDependencies.VaultHook;
-import net.md_5.bungee.api.chat.ClickEvent;
-import net.md_5.bungee.api.chat.TextComponent;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.ClickEvent;
 import net.milkbowl.vault.economy.Economy;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -122,26 +122,28 @@ public class ConfirmBuyGUI extends InventoryGUI{
                     p.getInventory().addItem(item);
 
                     p.sendMessage(M.getFormatted("chat.purchase-auction",
-                            "%seller%", M.formatSeller(note.getPlayerName(), note.getPlayerUUID()),
-                            "%item%", note.getItemName()));
+                            "seller", M.formatSeller(note.getPlayerName(), note.getPlayerUUID()),
+                            "item", note.getItemName()));
                     Player seller = Bukkit.getPlayer(note.getPlayerUUID());
                     if (SettingManager.soldMessageEnabled && seller != null && Bukkit.getOnlinePlayers().contains(seller)) {
                         String itemName = note.getItemName();
                         String amount = String.valueOf(item.getAmount());
-                        String buyer = M.formatBuyer(p.getDisplayName(), p.getUniqueId());
+                        Component buyer = M.formatBuyer(p.getDisplayName(), p.getUniqueId());
                         if(SettingManager.autoCollect) {
-                            seller.sendMessage(M.getFormatted("chat.sold-message.auto-collect", price,
-                                    "%buyer%", buyer,
-                                    "%item%", itemName,
-                                    "%amount%", amount));
+                            seller.sendMessage(M.getFormatted("chat.sold-message.auto-collect",
+                                    "price", price,
+                                    "buyer", buyer,
+                                    "item", itemName,
+                                    "amount", amount));
                         } else {
-                            TextComponent component = new TextComponent(M.getFormatted("chat.sold-message.prefix", price,
-                                    "%buyer%", buyer,
-                                    "%item%", itemName,
-                                    "%amount%", amount));
-                            TextComponent click = new TextComponent(M.getFormatted("chat.sold-message.interaction"));
-                            click.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/ah view " + note.getNoteID().toString()));
-                            seller.spigot().sendMessage(component, click);
+                            Component component = M.getFormatted("chat.sold-message.prefix",
+                                    "price", price,
+                                    "buyer", buyer,
+                                    "item", itemName,
+                                    "amount", amount);
+                            Component click = M.getFormatted("chat.sold-message.interaction")
+                                    .clickEvent(ClickEvent.runCommand("/ah view " + note.getNoteID()));
+                            seller.sendMessage(component.append(click));
                         }
                     }
                     if (SettingManager.autoCollect && Bukkit.getPlayer(note.getPlayerUUID()) != null) {

--- a/src/main/java/me/elaineqheart/auctionHouse/GUI/impl/EndedAuctionGUI.java
+++ b/src/main/java/me/elaineqheart/auctionHouse/GUI/impl/EndedAuctionGUI.java
@@ -13,6 +13,7 @@ import me.elaineqheart.auctionHouse.data.ram.AuctionHouseStorage;
 import me.elaineqheart.auctionHouse.data.ram.ItemManager;
 import me.elaineqheart.auctionHouse.data.ram.ItemNote;
 import me.elaineqheart.auctionHouse.pluginDependencies.VaultHook;
+import net.kyori.adventure.text.Component;
 import net.milkbowl.vault.economy.Economy;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -137,9 +138,9 @@ public class EndedAuctionGUI extends InventoryGUI implements Runnable{
                         return;
                     }
                     ItemStack item = note.getItem();
-                    String message = M.getFormatted("chat.claim-auction",
-                            "%item%", note.getItemName(),
-                            "%seller%", M.formatSeller(note.getPlayerName(), note.getPlayerUUID()));
+                    Component message = M.getFormatted("chat.claim-auction",
+                            "item", note.getItemName(),
+                            "seller", M.formatSeller(note.getPlayerName(), note.getPlayerUUID()));
 
                     boolean claimed = ItemNoteStorage.claimEndedAuctionItem(p, note);
                     if (!claimed) {
@@ -172,8 +173,9 @@ public class EndedAuctionGUI extends InventoryGUI implements Runnable{
                         Sounds.villagerDeny(event);
                         return;
                     }
-                    String message = M.getFormatted("chat.collect-coins", price,
-                            "%item%", note.getItemName());
+                    Component message = M.getFormatted("chat.collect-coins",
+                            "price", price,
+                            "item", note.getItemName());
 
                     boolean claimed = ItemNoteStorage.claimEndedAuctionItem(p, note);
                     if (!claimed) {

--- a/src/main/java/me/elaineqheart/auctionHouse/GUI/impl/MyAuctionsGUI.java
+++ b/src/main/java/me/elaineqheart/auctionHouse/GUI/impl/MyAuctionsGUI.java
@@ -253,10 +253,10 @@ public class MyAuctionsGUI extends InventoryGUI implements Runnable{
         ItemStack item = ConfigManager.layout.getItem("n");
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        meta.setItemName(M.getFormatted("items.next-page.name"));
-        meta.setLore(M.getLoreList("items.next-page.lore",
-                "%page%", String.valueOf(c.getMyCurrentPage()+1),
-                "%pages%", String.valueOf(pages+1)));
+        meta.itemName(M.getFormatted("items.next-page.name"));
+        meta.lore(M.getLoreList("items.next-page.lore",
+                "page", String.valueOf(c.getMyCurrentPage()+1),
+                "pages", String.valueOf(pages+1)));
         item.setItemMeta(meta);
         return new InventoryButton()
                 .creator(player -> item)
@@ -272,10 +272,10 @@ public class MyAuctionsGUI extends InventoryGUI implements Runnable{
         ItemStack item = ConfigManager.layout.getItem("p");
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        meta.setItemName(M.getFormatted("items.previous-page.name"));
-        meta.setLore(M.getLoreList("items.previous-page.lore",
-                "%page%", String.valueOf(c.getMyCurrentPage()+1),
-                "%pages%", String.valueOf(pages+1)));
+        meta.itemName(M.getFormatted("items.previous-page.name"));
+        meta.lore(M.getLoreList("items.previous-page.lore",
+                "page", String.valueOf(c.getMyCurrentPage()+1),
+                "pages", String.valueOf(pages+1)));
         item.setItemMeta(meta);
         return new InventoryButton()
                 .creator(player -> item)

--- a/src/main/java/me/elaineqheart/auctionHouse/GUI/impl/MyBidsGUI.java
+++ b/src/main/java/me/elaineqheart/auctionHouse/GUI/impl/MyBidsGUI.java
@@ -171,10 +171,10 @@ public class MyBidsGUI extends InventoryGUI implements Runnable {
         ItemStack item = ConfigManager.layout.getItem("n");
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        meta.setItemName(M.getFormatted("items.next-page.name"));
-        meta.setLore(M.getLoreList("items.next-page.lore",
-                "%page%", String.valueOf(page+1),
-                "%pages%", String.valueOf(pages+1)));
+        meta.itemName(M.getFormatted("items.next-page.name"));
+        meta.lore(M.getLoreList("items.next-page.lore",
+                "page", String.valueOf(page+1),
+                "pages", String.valueOf(pages+1)));
         item.setItemMeta(meta);
         return new InventoryButton()
                 .creator(player -> item)
@@ -189,10 +189,10 @@ public class MyBidsGUI extends InventoryGUI implements Runnable {
         ItemStack item = ConfigManager.layout.getItem("p");
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        meta.setItemName(M.getFormatted("items.previous-page.name"));
-        meta.setLore(M.getLoreList("items.previous-page.lore",
-                "%page%", String.valueOf(page+1),
-                "%pages%", String.valueOf((noteSize-1)/screenSize+1)));
+        meta.itemName(M.getFormatted("items.previous-page.name"));
+        meta.lore(M.getLoreList("items.previous-page.lore",
+                "page", String.valueOf(page+1),
+                "pages", String.valueOf((noteSize-1)/screenSize+1)));
         item.setItemMeta(meta);
         return new InventoryButton()
                 .creator(player -> item)

--- a/src/main/java/me/elaineqheart/auctionHouse/GUI/other/input/ChatInputManager.java
+++ b/src/main/java/me/elaineqheart/auctionHouse/GUI/other/input/ChatInputManager.java
@@ -20,7 +20,7 @@ public class ChatInputManager implements Listener {
     public void open(Player player, String inventoryTitle, InputHandler handler) {
         registerPlayer(player, handler);
         player.closeInventory();
-        player.sendMessage(M.getFormatted("chat.input-listener", "%request%", inventoryTitle));
+        player.sendMessage(M.getFormatted("chat.input-listener", "request", inventoryTitle));
     }
 
     private void registerPlayer(Player player, InputHandler handler) {

--- a/src/main/java/me/elaineqheart/auctionHouse/GUI/other/input/InputGUIManager.java
+++ b/src/main/java/me/elaineqheart/auctionHouse/GUI/other/input/InputGUIManager.java
@@ -20,7 +20,7 @@ public class InputGUIManager implements Listener {
 
     @SuppressWarnings("UnstableApiUsage")
     public void open(Player player, String inventoryTitleKey, InputHandler handler) {
-        String inventoryTitle = M.getFormatted(inventoryTitleKey);
+        String inventoryTitle = M.getString(inventoryTitleKey);
         try {
             MenuType.class.getName();
 

--- a/src/main/java/me/elaineqheart/auctionHouse/commands/AuctionHouseCommand.java
+++ b/src/main/java/me/elaineqheart/auctionHouse/commands/AuctionHouseCommand.java
@@ -18,6 +18,7 @@ import me.elaineqheart.auctionHouse.data.ram.ItemNote;
 import me.elaineqheart.auctionHouse.world.displays.CreateDisplay;
 import me.elaineqheart.auctionHouse.world.displays.UpdateDisplay;
 import me.elaineqheart.auctionHouse.world.npc.NPCManager;
+import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -47,7 +48,7 @@ public class AuctionHouseCommand implements CommandExecutor, TabCompleter {
     @Override
     public boolean onCommand(@NotNull CommandSender commandSender, @NotNull Command command, @NotNull String s, @NotNull String[] strings) {
         if(commandSender instanceof ConsoleCommandSender) {
-            if(strings.length == 1 && (strings[0].equals(M.getFormatted("commands.reload")))) {
+            if(strings.length == 1 && (strings[0].equals(M.getString("commands.reload")))) {
                 reload();
                 AuctionHouse.getInstance().getLogger().info("reloaded files");
                 return true;
@@ -61,7 +62,7 @@ public class AuctionHouseCommand implements CommandExecutor, TabCompleter {
                 }
                 AuctionHouse.getGuiManager().openGUI(new AuctionHouseGUI(p), p);
             }
-            if(strings.length==1 && strings[0].equals(M.getFormatted("commands.about"))) {
+            if(strings.length==1 && strings[0].equals(M.getString("commands.about"))) {
                 p.sendMessage("§6> §7§l---------------[ §dAuction House§7§l ]---------------");
                 p.sendMessage("§6> §7Made by:§6 ElaineQheart");
                 p.sendMessage("§6> §7Plugin Version:§6 " + AuctionHouse.getInstance().getDescription().getVersion());
@@ -72,30 +73,30 @@ public class AuctionHouseCommand implements CommandExecutor, TabCompleter {
                 //p.sendMessage("§6> §7The proletarians have nothing to lose but their chains");
                 p.sendMessage("§6> §7§l---------------[ §dAuction House§7§l ]---------------");
             }
-            if(strings.length==1 && strings[0].equals(M.getFormatted("commands.help"))) {
+            if(strings.length==1 && strings[0].equals(M.getString("commands.help"))) {
                 p.sendMessage(M.getFormatted("command-feedback.help-prefix"));
                 List<String> commands = Objects.requireNonNull(M.get().getConfigurationSection("command-feedback.help")).getKeys(false).stream().sorted().toList();
                 for(String cm : commands) {
-                    String message = M.getFormatted("command-feedback.help." + cm);
-                    if(cm.equals(M.getFormatted("commands.sell")) && !SettingManager.BINAuctions) continue;
-                    if(cm.equals(M.getFormatted("commands.bid")) && !SettingManager.BIDAuctions) continue;
-                    if(cm.equals(M.getFormatted("commands.announce")) && !SettingManager.auctionAnnouncementsEnabled) continue;
+                    Component message = M.getFormatted("command-feedback.help." + cm);
+                    if(cm.equals(M.getString("commands.sell")) && !SettingManager.BINAuctions) continue;
+                    if(cm.equals(M.getString("commands.bid")) && !SettingManager.BIDAuctions) continue;
+                    if(cm.equals(M.getString("commands.announce")) && !SettingManager.auctionAnnouncementsEnabled) continue;
                     if(adminCommands().contains(cm) && !p.hasPermission(SettingManager.permissionModerate)) continue;
                     p.sendMessage(message);
                 }
             }
-            if(strings.length==1 && strings[0].equals(M.getFormatted("commands.sell")) && SettingManager.BINAuctions) {
+            if(strings.length==1 && strings[0].equals(M.getString("commands.sell")) && SettingManager.BINAuctions) {
                 p.sendMessage(M.getFormatted("command-feedback.usage"));
             }
-            if(strings.length==1 && strings[0].equals(M.getFormatted("commands.bid")) && SettingManager.BIDAuctions) {
+            if(strings.length==1 && strings[0].equals(M.getString("commands.bid")) && SettingManager.BIDAuctions) {
                 p.sendMessage(M.getFormatted("command-feedback.bid-usage"));
             }
-            if(strings.length==1 && strings[0].equals(M.getFormatted("commands.search"))) {
+            if(strings.length==1 && strings[0].equals(M.getString("commands.search"))) {
                 p.sendMessage(M.getFormatted("command-feedback.search-usage"));
             }
-            if(strings.length==2 && strings[0].equals(M.getFormatted("commands.search"))) {
+            if(strings.length==2 && strings[0].equals(M.getString("commands.search"))) {
                 AhConfiguration conf = AhConfiguration.getInstance(p);
-                if (strings[1].equals(M.getFormatted("commands.search-cancel"))) {
+                if (strings[1].equals(M.getString("commands.search-cancel"))) {
                     conf.setCurrentSearch("");
                     Sounds.breakWood(p);
                 } else {
@@ -105,14 +106,14 @@ public class AuctionHouseCommand implements CommandExecutor, TabCompleter {
                 AuctionHouse.getGuiManager().openGUI(new AuctionHouseGUI(conf), p);
             }
             if((strings.length==2 || strings.length==3) &&
-                    (strings[0].equals(M.getFormatted("commands.sell")) && SettingManager.BINAuctions
-                            || strings[0].equals(M.getFormatted("commands.bid")) && SettingManager.BIDAuctions)) {
+                    (strings[0].equals(M.getString("commands.sell")) && SettingManager.BINAuctions
+                            || strings[0].equals(M.getString("commands.bid")) && SettingManager.BIDAuctions)) {
                 if(ConfigManager.bannedPlayers.checkIsBannedSendMessage(p)) {
                     return true;
                 }
                 if(AuctionHouseStorage.getNumberOfAuctions(p.getUniqueId()) >= ConfigManager.permissions.getAuctionSlots(p)) {
                     p.sendMessage(M.getFormatted("command-feedback.reached-max-auctions",
-                            "%limit%", String.valueOf(ConfigManager.permissions.getAuctionSlots(p))));
+                            "limit", String.valueOf(ConfigManager.permissions.getAuctionSlots(p))));
                     return true;
                 }
                 ItemStack item = p.getInventory().getItemInMainHand();
@@ -129,18 +130,18 @@ public class AuctionHouseCommand implements CommandExecutor, TabCompleter {
                     p.sendMessage(M.getFormatted("command-feedback.invalid-number2"));
                     return true;
                 }
-                if (strings[0].equals(M.getFormatted("commands.sell")) && price < SettingManager.minBINPrice) {
-                    p.sendMessage(M.getFormatted("command-feedback.min-bin", SettingManager.minBINPrice));
+                if (strings[0].equals(M.getString("commands.sell")) && price < SettingManager.minBINPrice) {
+                    p.sendMessage(M.getFormatted("command-feedback.min-bin", "price", SettingManager.minBINPrice));
                     return true;
-                } else if (strings[0].equals(M.getFormatted("commands.bid")) && price < SettingManager.minBIDPrice) {
-                    p.sendMessage(M.getFormatted("command-feedback.min-bid", SettingManager.minBIDPrice));
+                } else if (strings[0].equals(M.getString("commands.bid")) && price < SettingManager.minBIDPrice) {
+                    p.sendMessage(M.getFormatted("command-feedback.min-bid", "price", SettingManager.minBIDPrice));
                     return true;
                 }
-                if (SettingManager.maxBINPrice > -1 && strings[0].equals(M.getFormatted("commands.sell")) && price > SettingManager.maxBINPrice) {
-                    p.sendMessage(M.getFormatted("command-feedback.max-bin", SettingManager.maxBINPrice));
+                if (SettingManager.maxBINPrice > -1 && strings[0].equals(M.getString("commands.sell")) && price > SettingManager.maxBINPrice) {
+                    p.sendMessage(M.getFormatted("command-feedback.max-bin", "price", SettingManager.maxBINPrice));
                     return true;
-                } else if (SettingManager.maxBIDPrice > -1 && strings[0].equals(M.getFormatted("commands.bid")) && price > SettingManager.maxBIDPrice) {
-                    p.sendMessage(M.getFormatted("command-feedback.max-bid", SettingManager.maxBIDPrice));
+                } else if (SettingManager.maxBIDPrice > -1 && strings[0].equals(M.getString("commands.bid")) && price > SettingManager.maxBIDPrice) {
+                    p.sendMessage(M.getFormatted("command-feedback.max-bid", "price", SettingManager.maxBIDPrice));
                     return true;
                 }
                 int amount = item.getAmount();
@@ -161,18 +162,18 @@ public class AuctionHouseCommand implements CommandExecutor, TabCompleter {
                 ItemStack inputItem = item.clone();
                 inputItem.setAmount(amount);
                 item.setAmount(item.getAmount() - amount);
-                ItemNote note = ItemNoteStorage.createNote(p, inputItem, price, strings[0].equals(M.getFormatted("commands.bid")));
-                p.sendMessage(M.getFormatted("command-feedback.auction", price));
+                ItemNote note = ItemNoteStorage.createNote(p, inputItem, price, strings[0].equals(M.getString("commands.bid")));
+                p.sendMessage(M.getFormatted("command-feedback.auction", "price", price));
                 
                 // Announce the new auction to all players who have announcements enabled
                 if(SettingManager.auctionAnnouncementsEnabled) {
                     String itemName = note.getItemName();
-                    String announcement = M.getFormatted(
-                            strings[0].equals(M.getFormatted("commands.sell")) ? "chat.auction-announcement" : "chat.bid-announcement",
-                            price,
-                            "%player%", M.formatPlayer(p.getDisplayName(), p.getUniqueId()),
-                            "%item%", itemName,
-                            "%amount%", String.valueOf(amount));
+                    Component announcement = M.getFormatted(
+                            strings[0].equals(M.getString("commands.sell")) ? "chat.auction-announcement" : "chat.bid-announcement",
+                            "price", price,
+                            "player", M.formatPlayer(p.getDisplayName(), p.getUniqueId()),
+                            "item", itemName,
+                            "amount", String.valueOf(amount));
                     if (SettingManager.auctionSetupTime == 0) {
                         for (Player onlinePlayer : Bukkit.getOnlinePlayers()) {
                             if (ConfigManager.playerPreferences.hasAnnouncementsEnabled(onlinePlayer.getUniqueId()) && !onlinePlayer.equals(p)) {
@@ -192,7 +193,7 @@ public class AuctionHouseCommand implements CommandExecutor, TabCompleter {
 
             }
             // /ah announce - toggle announcements
-            if(strings.length == 1 && SettingManager.auctionAnnouncementsEnabled && strings[0].equals(M.getFormatted("commands.announce"))) {
+            if(strings.length == 1 && SettingManager.auctionAnnouncementsEnabled && strings[0].equals(M.getString("commands.announce"))) {
                 boolean newState = ConfigManager.playerPreferences.toggleAnnouncements(p);
                 if(newState) {
                     p.sendMessage(M.getFormatted("command-feedback.announcements-enabled"));
@@ -219,14 +220,14 @@ public class AuctionHouseCommand implements CommandExecutor, TabCompleter {
             }
             // /ah admin
             if(p.hasPermission(SettingManager.permissionModerate) && strings.length > 0) {
-                if(strings.length == 1 && strings[0].equals(M.getFormatted("commands.admin"))) {
+                if(strings.length == 1 && strings[0].equals(M.getString("commands.admin"))) {
                     AuctionHouse.getGuiManager().openGUI(new AuctionHouseGUI(0, AuctionHouseGUI.Sort.HIGHEST_PRICE, "", p, true), p);
-                } else if (strings.length < 4 && strings[0].equals(M.getFormatted("commands.ban"))) {
+                } else if (strings.length < 4 && strings[0].equals(M.getString("commands.ban"))) {
                     p.sendMessage(M.getFormatted("command-feedback.ban-usage"));
-                } else if (strings.length != 2 && strings[0].equals(M.getFormatted("commands.pardon"))) {
+                } else if (strings.length != 2 && strings[0].equals(M.getString("commands.pardon"))) {
                     p.sendMessage(M.getFormatted("command-feedback.pardon-usage"));
                     // /ah ban player:
-                } else if (strings.length > 3 && strings[0].equals(M.getFormatted("commands.ban"))) {
+                } else if (strings.length > 3 && strings[0].equals(M.getString("commands.ban"))) {
                     Player targetPlayer = Bukkit.getPlayer(strings[1]);
                     if (targetPlayer==null) {
                         p.sendMessage(M.getFormatted("command-feedback.player-not-found"));
@@ -248,14 +249,14 @@ public class AuctionHouseCommand implements CommandExecutor, TabCompleter {
                         }
                         ConfigManager.bannedPlayers.saveBannedPlayer(targetPlayer, duration, reason.toString());
                         p.sendMessage(M.getFormatted("command-feedback.ban",
-                                "%player%", M.formatPlayer(targetPlayer.getDisplayName(), targetPlayer.getUniqueId()),
-                                "%duration%", String.valueOf(duration),
-                                "%reason%", reason.toString()));
+                                "player", M.formatPlayer(targetPlayer.getDisplayName(), targetPlayer.getUniqueId()),
+                                "duration", String.valueOf(duration),
+                                "reason", reason.toString()));
                     } catch (Exception e) {
                         p.sendMessage(M.getFormatted("command-feedback.invalid-number4"));
                     }
                     // /ah pardon player:
-                } else if (strings.length == 2 && strings[0].equals(M.getFormatted("commands.pardon"))) {
+                } else if (strings.length == 2 && strings[0].equals(M.getString("commands.pardon"))) {
                     String input = strings[1];
                     ConfigurationSection section = ConfigManager.bannedPlayers.getCustomFile().getConfigurationSection("BannedPlayers");
                     if (section == null) {
@@ -270,19 +271,19 @@ public class AuctionHouseCommand implements CommandExecutor, TabCompleter {
                             ConfigManager.bannedPlayers.getCustomFile().set("BannedPlayers." + key, null);
                             ConfigManager.bannedPlayers.save();
                             p.sendMessage(M.getFormatted("command-feedback.pardon",
-                                    "%player%", M.formatPlayer(playerName, UUID.fromString(key))));
+                                    "player", M.formatPlayer(playerName, UUID.fromString(key))));
                             return true;
                         }
                     }
                     p.sendMessage(M.getFormatted("command-feedback.not-banned"));
 
-                } else if (strings[0].equals(M.getFormatted("commands.reload"))) {
+                } else if (strings[0].equals(M.getString("commands.reload"))) {
                     reload();
                     p.sendMessage(M.getFormatted("command-feedback.reload"));
                     AuctionHouse.getInstance().getLogger().info("reloaded");
                     return true;
 
-                } else if (strings[0].equals(M.getFormatted("commands.summon"))) {
+                } else if (strings[0].equals(M.getString("commands.summon"))) {
                     if(strings.length < 2) {
                         p.sendMessage(M.getFormatted("command-feedback.summon-usage"));
                         return true;
@@ -293,13 +294,13 @@ public class AuctionHouseCommand implements CommandExecutor, TabCompleter {
                     Location blockLoc = new Location(loc.getWorld(), loc.getBlockX(), loc.getBlockY(), loc.getBlockZ());
 
 
-                    if(strings[1].equals(M.getFormatted("commands.npc"))) {
+                    if(strings[1].equals(M.getString("commands.npc"))) {
                         if(strings.length < 4) {
                             p.sendMessage(M.getFormatted("command-feedback.npc-usage"));
                             return true;
                         }
                         NPCManager.createAuctionMaster(middleBlockLoc, strings[3]);
-                    } else if(strings[1].equals(M.getFormatted("commands.display"))) {
+                    } else if(strings[1].equals(M.getString("commands.display"))) {
                         if(strings.length < 4) {
                             p.sendMessage(M.getFormatted("command-feedback.display-usage"));
                             return true;
@@ -326,34 +327,34 @@ public class AuctionHouseCommand implements CommandExecutor, TabCompleter {
                             p.sendMessage(M.getFormatted("command-feedback.no-air-space-for-display"));
                             return true;
                         }
-                        if(strings[2].equals(M.getFormatted("commands.highest_price"))) {
+                        if(strings[2].equals(M.getString("commands.highest_price"))) {
                                 CreateDisplay.createDisplayHighestPrice(blockLoc, itemNumber);
-                        } else if (strings[2].equals(M.getFormatted("commands.ending_soon"))) {
+                        } else if (strings[2].equals(M.getString("commands.ending_soon"))) {
                             CreateDisplay.createDisplayEndingSoon(blockLoc, itemNumber);
                         } else {
                             p.sendMessage(M.getFormatted("command-feedback.display-usage"));
                             return true;
                         }
                     }
-                } else if (strings.length == 2 && strings[1].equals(M.getFormatted("commands.undo"))) {
+                } else if (strings.length == 2 && strings[1].equals(M.getString("commands.undo"))) {
                     if (ConfigManager.blacklist.undo()) {
                         p.sendMessage(M.getFormatted("command-feedback.blacklist-undo"));
                     } else {
                         p.sendMessage(M.getFormatted("command-feedback.blacklist-undo-error"));
                     }
                     return true;
-                } else if (strings.length < 3 && strings[0].equals(M.getFormatted("commands.blacklist"))) {
+                } else if (strings.length < 3 && strings[0].equals(M.getString("commands.blacklist"))) {
                     p.sendMessage(M.getFormatted("command-feedback.blacklist-usage"));
                     return true;
-                } else if (strings.length == 3 && strings[0].equals(M.getFormatted("commands.blacklist"))
-                        && strings[1].equals(M.getFormatted("commands.add"))) {
-                     if (strings[2].equals(M.getFormatted("commands.all"))) {
+                } else if (strings.length == 3 && strings[0].equals(M.getString("commands.blacklist"))
+                        && strings[1].equals(M.getString("commands.add"))) {
+                     if (strings[2].equals(M.getString("commands.all"))) {
                          ConfigManager.blacklist.addAll();
                         p.sendMessage(M.getFormatted("command-feedback.blacklist-all"));
                         return true;
                     }
-                    if (strings[2].equals(M.getFormatted("commands.exact")) || strings[2].equals(M.getFormatted("commands.material"))
-                            || strings[2].equals(M.getFormatted("commands.item_model"))) {
+                    if (strings[2].equals(M.getString("commands.exact")) || strings[2].equals(M.getString("commands.material"))
+                            || strings[2].equals(M.getString("commands.item_model"))) {
                         ItemStack item = p.getInventory().getItemInMainHand();
                         if (item.getType().equals(Material.AIR)) {
                             p.sendMessage(M.getFormatted("command-feedback.blacklist-no-item-in-hand"));
@@ -361,43 +362,43 @@ public class AuctionHouseCommand implements CommandExecutor, TabCompleter {
                         }
                         ItemMeta meta = item.getItemMeta();
                         assert meta != null;
-                        if (strings[2].equals(M.getFormatted("commands.exact"))) {
+                        if (strings[2].equals(M.getString("commands.exact"))) {
                             ConfigManager.blacklist.addExact(item);
-                        } else if (strings[2].equals(M.getFormatted("commands.material"))){
+                        } else if (strings[2].equals(M.getString("commands.material"))){
                             ConfigManager.blacklist.addMaterial(item.getType().toString());
-                        } else if (strings[2].equals(M.getFormatted("commands.item_model"))) {
+                        } else if (strings[2].equals(M.getString("commands.item_model"))) {
                             if(item.getItemMeta().getItemModel() == null) {
                                 p.sendMessage(M.getFormatted("command-feedback.blacklist-no-model"));
                                 return true;
                             }
                             else ConfigManager.blacklist.addItemModel(item.getItemMeta().getItemModel().getKey());
-                            p.sendMessage(M.getFormatted("command-feedback.blacklist-name-success", "%name%",
+                            p.sendMessage(M.getFormatted("command-feedback.blacklist-name-success", "name",
                                     item.getItemMeta().getItemModel().getKey()));
                             return true;
                         }
-                        p.sendMessage(M.getFormatted("command-feedback.blacklist-success", "%item%", item.getType().name()));
+                        p.sendMessage(M.getFormatted("command-feedback.blacklist-success", "item", item.getType().name()));
                         return true;
                     }
                     p.sendMessage(M.getFormatted("command-feedback.blacklist-usage"));
                     return true;
-                } else if (strings.length == 4 && strings[0].equals(M.getFormatted("commands.blacklist"))
-                    && strings[1].equals(M.getFormatted("commands.add"))) {
+                } else if (strings.length == 4 && strings[0].equals(M.getString("commands.blacklist"))
+                    && strings[1].equals(M.getString("commands.add"))) {
 
-                    if (strings[2].equals(M.getFormatted("commands.exact")) || strings[2].equals(M.getFormatted("commands.material"))) return true;
+                    if (strings[2].equals(M.getString("commands.exact")) || strings[2].equals(M.getString("commands.material"))) return true;
 
-                    if(strings[2].equals(M.getFormatted("commands.contains_lore"))) {
+                    if(strings[2].equals(M.getString("commands.contains_lore"))) {
                         ConfigManager.blacklist.addLoreContains(strings[3]);
-                    } else if (strings[2].equals(M.getFormatted("commands.name_contains"))) {
+                    } else if (strings[2].equals(M.getString("commands.name_contains"))) {
                         ConfigManager.blacklist.addNameContains(strings[3]);
-                    } else if (strings[2].equals(M.getFormatted("commands.custom_model_data"))) {
+                    } else if (strings[2].equals(M.getString("commands.custom_model_data"))) {
                         ConfigManager.blacklist.addCustomModelData(strings[3]);
-                    } else if (strings[2].equals(M.getFormatted("commands.item_model"))) {
+                    } else if (strings[2].equals(M.getString("commands.item_model"))) {
                         ConfigManager.blacklist.addItemModel((strings[3]));
                     }
-                    p.sendMessage(M.getFormatted("command-feedback.blacklist-name-success", "%name%", strings[3]));
+                    p.sendMessage(M.getFormatted("command-feedback.blacklist-name-success", "name", strings[3]));
                     return true;
-                } else if (strings.length == 2 && strings[0].equals(M.getFormatted("commands.test"))
-                        && strings[1].equals(M.getFormatted("commands.save-item-to-layout-file"))) {
+                } else if (strings.length == 2 && strings[0].equals(M.getString("commands.test"))
+                        && strings[1].equals(M.getString("commands.save-item-to-layout-file"))) {
                     p.sendMessage(M.getFormatted("command-feedback.item-saved-to-layout-file"));
                     ConfigManager.layout.saveItem(p.getInventory().getItemInMainHand());
                     return true;
@@ -415,12 +416,12 @@ public class AuctionHouseCommand implements CommandExecutor, TabCompleter {
         if(strings.length==1) {
             //check for every item if it's half typed out, then add accordingly to the params list
             List<String> assetParams = new ArrayList<>();
-            assetParams.add(M.getFormatted("commands.about"));
-            assetParams.add(M.getFormatted("commands.help"));
-            assetParams.add(M.getFormatted("commands.search"));
-            if(SettingManager.BINAuctions) assetParams.add(M.getFormatted("commands.sell"));
-            if(SettingManager.BIDAuctions) assetParams.add(M.getFormatted("commands.bid"));
-            if(SettingManager.auctionAnnouncementsEnabled) assetParams.add(M.getFormatted("commands.announce"));
+            assetParams.add(M.getString("commands.about"));
+            assetParams.add(M.getString("commands.help"));
+            assetParams.add(M.getString("commands.search"));
+            if(SettingManager.BINAuctions) assetParams.add(M.getString("commands.sell"));
+            if(SettingManager.BIDAuctions) assetParams.add(M.getString("commands.bid"));
+            if(SettingManager.auctionAnnouncementsEnabled) assetParams.add(M.getString("commands.announce"));
             if(commandSender.hasPermission(SettingManager.permissionModerate)) assetParams.addAll(adminCommands());
             for (String p : assetParams) {
                 if (p.indexOf(strings[0]) == 0){
@@ -429,11 +430,11 @@ public class AuctionHouseCommand implements CommandExecutor, TabCompleter {
             }
 
         }
-        if(strings.length == 2 && strings[0].equals(M.getFormatted("commands.ban"))) {
+        if(strings.length == 2 && strings[0].equals(M.getString("commands.ban"))) {
             for (Player p : Bukkit.getOnlinePlayers()) {
                 params.add(p.getDisplayName());
             }
-        } else if (strings.length == 2 && strings[0].equals(M.getFormatted("commands.pardon"))) {
+        } else if (strings.length == 2 && strings[0].equals(M.getString("commands.pardon"))) {
             ConfigurationSection section = ConfigManager.bannedPlayers.getCustomFile().getConfigurationSection("BannedPlayers");
             if (section != null) {
                 for(String key : section.getKeys(false)) {
@@ -441,57 +442,57 @@ public class AuctionHouseCommand implements CommandExecutor, TabCompleter {
                     params.add(ConfigManager.bannedPlayers.getCustomFile().getString(path));
                 }
             }
-        } else if (strings.length == 2 && strings[0].equals(M.getFormatted("commands.summon"))) {
-            List<String> summonTypes = new ArrayList<>(List.of(new String[]{M.getFormatted("commands.npc"),
-                    M.getFormatted("commands.display")}));
+        } else if (strings.length == 2 && strings[0].equals(M.getString("commands.summon"))) {
+            List<String> summonTypes = new ArrayList<>(List.of(new String[]{M.getString("commands.npc"),
+                    M.getString("commands.display")}));
             for (String p : summonTypes) {
                 if (p.indexOf(strings[1]) == 0) {
                     params.add(p);
                 }
             }
-        } else if (strings.length == 2 && strings[0].equals(M.getFormatted("commands.blacklist"))) {
-            List<String> summonTypes = new ArrayList<>(List.of(new String[]{M.getFormatted("commands.add"),
-                    M.getFormatted("commands.undo")}));
+        } else if (strings.length == 2 && strings[0].equals(M.getString("commands.blacklist"))) {
+            List<String> summonTypes = new ArrayList<>(List.of(new String[]{M.getString("commands.add"),
+                    M.getString("commands.undo")}));
             for (String p : summonTypes) {
                 if (p.indexOf(strings[1]) == 0) {
                     params.add(p);
                 }
             }
-        } else if (strings.length == 3 && strings[0].equals(M.getFormatted("commands.summon")) && strings[1].equals(M.getFormatted("commands.display"))) {
-            List<String> displayTypes = new ArrayList<>(List.of(new String[]{M.getFormatted("commands.highest_price"),
-                    M.getFormatted("commands.ending_soon")}));
+        } else if (strings.length == 3 && strings[0].equals(M.getString("commands.summon")) && strings[1].equals(M.getString("commands.display"))) {
+            List<String> displayTypes = new ArrayList<>(List.of(new String[]{M.getString("commands.highest_price"),
+                    M.getString("commands.ending_soon")}));
             for (String p : displayTypes) {
                 if (p.indexOf(strings[2]) == 0){
                     params.add(p);
                 }
             }
-        } else if (strings.length == 3 && strings[0].equals(M.getFormatted("commands.summon")) && strings[1].equals(M.getFormatted("commands.npc"))) {
-            List<String> displayTypes = new ArrayList<>(List.of(new String[]{M.getFormatted("commands.facing")}));
+        } else if (strings.length == 3 && strings[0].equals(M.getString("commands.summon")) && strings[1].equals(M.getString("commands.npc"))) {
+            List<String> displayTypes = new ArrayList<>(List.of(new String[]{M.getString("commands.facing")}));
             for (String p : displayTypes) {
                 if (p.indexOf(strings[2]) == 0) {
                     params.add(p);
                 }
             }
-        } else if (strings.length == 3 && strings[0].equals(M.getFormatted("commands.blacklist")) && strings[1].equals(M.getFormatted("commands.add"))) {
-            List<String> displayTypes = new ArrayList<>(List.of(new String[]{M.getFormatted("commands.exact"),
-                    M.getFormatted("commands.material"), M.getFormatted("commands.name_contains"),
-                    M.getFormatted("commands.contains_lore"), M.getFormatted("commands.item_model"),
-                    M.getFormatted("commands.custom_model_data"), M.getFormatted("commands.all")}));
+        } else if (strings.length == 3 && strings[0].equals(M.getString("commands.blacklist")) && strings[1].equals(M.getString("commands.add"))) {
+            List<String> displayTypes = new ArrayList<>(List.of(new String[]{M.getString("commands.exact"),
+                    M.getString("commands.material"), M.getString("commands.name_contains"),
+                    M.getString("commands.contains_lore"), M.getString("commands.item_model"),
+                    M.getString("commands.custom_model_data"), M.getString("commands.all")}));
             for (String p : displayTypes) {
                 if (p.indexOf(strings[2]) == 0){
                     params.add(p);
                 }
             }
-        } else if (strings.length == 4 && strings[0].equals(M.getFormatted("commands.summon")) && strings[1].equals(M.getFormatted("commands.npc"))) {
-            List<String> displayTypes = new ArrayList<>(List.of(new String[]{M.getFormatted("commands.north"), M.getFormatted("commands.east"),
-                    M.getFormatted("commands.south"), M.getFormatted("commands.west")}));
+        } else if (strings.length == 4 && strings[0].equals(M.getString("commands.summon")) && strings[1].equals(M.getString("commands.npc"))) {
+            List<String> displayTypes = new ArrayList<>(List.of(new String[]{M.getString("commands.north"), M.getString("commands.east"),
+                    M.getString("commands.south"), M.getString("commands.west")}));
             for (String p : displayTypes) {
                 if (p.indexOf(strings[3]) == 0) {
                     params.add(p);
                 }
             }
-        } else if (strings.length == 2 && strings[0].equals(M.getFormatted("commands.test"))) {
-            List<String> summonTypes = new ArrayList<>(List.of(new String[]{M.getFormatted("commands.save-item-to-layout-file")}));
+        } else if (strings.length == 2 && strings[0].equals(M.getString("commands.test"))) {
+            List<String> summonTypes = new ArrayList<>(List.of(new String[]{M.getString("commands.save-item-to-layout-file")}));
             for (String p : summonTypes) {
                 if (p.indexOf(strings[1]) == 0) {
                     params.add(p);
@@ -516,13 +517,13 @@ public class AuctionHouseCommand implements CommandExecutor, TabCompleter {
 
     private static List<String> adminCommands() {
         List<String> commandsList = new ArrayList<>();
-        commandsList.add(M.getFormatted("commands.admin"));
-        commandsList.add(M.getFormatted("commands.ban"));
-        commandsList.add(M.getFormatted("commands.pardon"));
-        commandsList.add(M.getFormatted("commands.reload"));
-        commandsList.add(M.getFormatted("commands.summon"));
-        commandsList.add(M.getFormatted("commands.blacklist"));
-        commandsList.add(M.getFormatted("commands.test"));
+        commandsList.add(M.getString("commands.admin"));
+        commandsList.add(M.getString("commands.ban"));
+        commandsList.add(M.getString("commands.pardon"));
+        commandsList.add(M.getString("commands.reload"));
+        commandsList.add(M.getString("commands.summon"));
+        commandsList.add(M.getString("commands.blacklist"));
+        commandsList.add(M.getString("commands.test"));
         return commandsList;
     }
 }

--- a/src/main/java/me/elaineqheart/auctionHouse/commands/DynamicCommandRegisterer.java
+++ b/src/main/java/me/elaineqheart/auctionHouse/commands/DynamicCommandRegisterer.java
@@ -15,7 +15,7 @@ import java.util.List;
 public class DynamicCommandRegisterer {
 
     public static void init() {
-        String name = M.getFormatted("commands.ah").toLowerCase();
+        String name = M.getString("commands.ah").toLowerCase();
         List<String> aliases = ConfigManager.messages.getCustomFile().getStringList("commands.aliases");
         //String alias = M.getFormatted("commands.alias").toLowerCase();
         //List<String> aliases = alias.isEmpty() ? List.of() : List.of(alias);

--- a/src/main/java/me/elaineqheart/auctionHouse/data/StringUtils.java
+++ b/src/main/java/me/elaineqheart/auctionHouse/data/StringUtils.java
@@ -2,6 +2,7 @@ package me.elaineqheart.auctionHouse.data;
 
 import me.elaineqheart.auctionHouse.data.persistentStorage.local.SettingManager;
 import me.elaineqheart.auctionHouse.data.persistentStorage.local.configs.M;
+import net.kyori.adventure.text.Component;
 import org.bukkit.*;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Item;
@@ -66,23 +67,23 @@ public class StringUtils {
         }
     }
 
-    public static String formatNumber(double number) {
-        return M.getFormatted("placeholders.number", "%input%", formatNumberPlain(number));
+    public static Component formatNumber(double number) {
+        return M.getFormatted("placeholders.number", "input", formatNumberPlain(number));
     }
     public static String formatNumberPlain(double number) {
         // fallback for async threads
         DecimalFormat fmt = Objects.requireNonNullElseGet(SettingManager.formatter, () ->
-                new DecimalFormat(M.getFormatted("placeholders.format-numbers")));
+                new DecimalFormat(M.getString("placeholders.format-numbers")));
         return fmt.format(number);
     }
-    public static String formatNumber(String number) {
-        return M.getFormatted("placeholders.number", "%input%", number);
+    public static Component formatNumber(String number) {
+        return M.getFormatted("placeholders.number", "input", number);
     }
 
-    public static String formatPrice(double price, boolean trimmed) {
+    public static Component formatPrice(double price, boolean trimmed) {
         return M.getFormatted("placeholders.price",
-                "%number%", formatNumber(trimmed ? StringUtils.getPriceTrimmed(price) : formatNumber(price)),
-                "%currency-symbol%", M.getFormatted("placeholders.currency-symbol"));
+                "number", trimmed ? formatNumber(getPriceTrimmed(price)) : formatNumber(price),
+                "currency-symbol", M.getFormatted("placeholders.currency-symbol"));
     }
 
     public static String getItemName(ItemStack item) {

--- a/src/main/java/me/elaineqheart/auctionHouse/data/persistentStorage/local/SettingManager.java
+++ b/src/main/java/me/elaineqheart/auctionHouse/data/persistentStorage/local/SettingManager.java
@@ -42,7 +42,6 @@ public class SettingManager {
     public static double minBIDPrice;
     public static double maxBINPrice;
     public static double maxBIDPrice;
-    public static boolean useAdventureAPIMessages;
     public static String soundClick;
     public static String soundOpenEnderchest;
     public static String soundCloseEnderchest;
@@ -69,7 +68,6 @@ public class SettingManager {
         AuctionHouse.getInstance().reloadConfig();
         FileConfiguration c = AuctionHouse.getInstance().getConfig();
 
-        useAdventureAPIMessages = c.getBoolean("use-adventure-text-minimessages", true);
         if (ConfigManager.backwardsCompatibility())
             backwardsCompatibility();
 
@@ -81,7 +79,7 @@ public class SettingManager {
         auctionSetupTime = c.getLong("auction-setup-time", 30);
         defaultMaxAuctions = c.getInt("default-max-auctions", 10);
         soldMessageEnabled = c.getBoolean("sold-message", true);
-        formatter = new DecimalFormat(M.getFormatted("placeholders.format-numbers"));
+        formatter = new DecimalFormat(M.getString("placeholders.format-numbers"));
         formatTimeCharacters = c.getString("format-time-characters", "dhms");
         permissionModerate = c.getString("admin-permission", "auctionhouse.moderator");
         partialSelling = c.getBoolean("partial-selling", false);
@@ -252,8 +250,8 @@ public class SettingManager {
             messageFile.set("world.displays.line-3", messageFile.get("world.displays.sign-interaction"));
             messageFile.set("world.displays.sign-interaction", null);
             String by = messageFile.getString("world.displays.by-player");
-            if (by != null && !by.contains("%player%")) {
-                messageFile.set("world.displays.by-player", messageFile.get("world.displays.by-player") + "%player%");
+            if (by != null && !by.contains("%player%") && !by.contains("<player>")) {
+                messageFile.set("world.displays.by-player", messageFile.get("world.displays.by-player") + "<player>");
             }
         }
         if (messageFile.contains("commands.alias")) {

--- a/src/main/java/me/elaineqheart/auctionHouse/data/persistentStorage/local/configs/M.java
+++ b/src/main/java/me/elaineqheart/auctionHouse/data/persistentStorage/local/configs/M.java
@@ -2,25 +2,38 @@ package me.elaineqheart.auctionHouse.data.persistentStorage.local.configs;
 
 import me.clip.placeholderapi.PlaceholderAPI;
 import me.elaineqheart.auctionHouse.data.StringUtils;
-import me.elaineqheart.auctionHouse.data.persistentStorage.local.SettingManager;
 import me.elaineqheart.auctionHouse.data.persistentStorage.local.data.Config;
 import me.elaineqheart.auctionHouse.data.persistentStorage.local.data.ConfigManager;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
-import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import net.kyori.adventure.text.minimessage.tag.Tag;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.configuration.file.FileConfiguration;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class M extends Config {
 
-    private static final LegacyComponentSerializer legacy = LegacyComponentSerializer.legacySection();
-    private static final MiniMessage mm = MiniMessage.miniMessage();
+    private static final MiniMessage mm = MiniMessage.builder()
+            .preProcessor(M::convertLegacyInput)
+            .build();
+
+    // legacy %placeholder% tokens that are rewritten to MiniMessage tags so old configs keep working
+    private static final Pattern LEGACY_PLACEHOLDER = Pattern.compile("%([a-zA-Z][a-zA-Z0-9_-]*)%");
+    private static final Set<String> KNOWN_PLACEHOLDERS = Set.of(
+            "player", "seller", "buyer", "price", "price-trim", "number",
+            "item", "amount", "time", "reason", "request", "filter",
+            "page", "pages", "tax", "amountOfBids", "sold", "total",
+            "duration", "limit", "name", "input", "currency-symbol", "player_name");
 
     // AuctionHouse.getPlugin().saveResource("messages.yml", false);
 
@@ -28,100 +41,170 @@ public class M extends Config {
         return ConfigManager.messages.getCustomFile();
     }
 
-    private static String getValue(String key, boolean convertNewLine) {
+    private static String getValue(String key) {
         String message = get().getString(key);
         if (message == null) {
-            return ChatColor.RED + "Missing message key: " + key;
+            return "<red>Missing message key: " + key;
         }
-        return convertNewLine ? message.replace("&n", "\n") : message;
+        return message.replace("&n", "\n");
     }
 
-    //this is to replace placeholders like %player%
-    public static String getFormatted(String key, String... replacements) {
-        String message = getValue(key,true);
-        message = replacePlaceholders(key, message, replacements);
-        return adventureApi(message);
-    }
-    public static String getFormatted(String key, double price, String... replacements) {
-        String message = getValue(key,true);
-        message = replacePlaceholders(key, message, replacements);
-        message = replace(message, price);
-        return adventureApi(message);
+    public static Component getFormatted(String key, Object... replacements) {
+        if (replacements.length % 2 != 0) return error("Invalid placeholder replacements for key: " + key);
+        return deserialize(getValue(key), resolverOf(replacements));
     }
 
-    public static List<String> getLoreList(String key, String... replacements) {
-        String message = getValue(key,false);
-        message = replacePlaceholders(key, message, replacements);
-        List<String> list = Arrays.asList(message.split("&n"));
-        list.replaceAll(M::adventureApi);
-        return list;
-    }
-    public static List<String> getLoreList(String key, double price, String... replacements) {
-        String message = getValue(key,false);
-        message = replacePlaceholders(key, message, replacements);
-        message = replace(message, price);
-        List<String> list = Arrays.asList(message.split("&n"));
-        list.replaceAll(M::adventureApi);
-        return list;
+    public static List<Component> getLoreList(String key, Object... replacements) {
+        if (replacements.length % 2 != 0) return List.of(error("Invalid placeholder replacements for key: " + key));
+        return Arrays.stream(getValue(key).split("\n", -1))
+                .map(line -> deserialize(line, resolverOf(replacements)))
+                .toList();
     }
 
-    private static String replacePlaceholders(String key, String message, String... replacements) {
-        if (replacements.length % 2 != 0) {
-            return ChatColor.RED + "Invalid placeholder replacements for key: " + key;
-        }
-        for (int i = 0; i < replacements.length; i += 2) {
-            message = message.replace(replacements[i], replacements[i + 1]);
-        }
-        return message;
+    // plain text, used for command names, decimal formats and anvil titles
+    public static String getString(String key) {
+        return PlainTextComponentSerializer.plainText().serialize(getFormatted(key));
     }
 
-    public static String replace(String message, double... prices) {
-        message = message.replace("%price%", StringUtils.formatPrice(prices[0], false));
-        message = message.replace("%price-trim%", StringUtils.formatPrice(prices[0], true));
-        message = message.replace("%number%", StringUtils.formatNumber(prices[0]));
-        for(int i = 2; i-1 < prices.length; i++) {
-            message = message.replace("%price"+i+"%", StringUtils.formatPrice(prices[i-1], false));
-            message = message.replace("%price-trim"+i+"%", StringUtils.formatPrice(prices[i-1], true));
-            message = message.replace("%number"+i+"%", StringUtils.formatNumber(prices[i-1]));
-        }
-        return message;
+    // parses arbitrary text (item names, admin input) through the same MiniMessage pipeline
+    public static Component deserialize(String input) {
+        return safeDeserialize(input);
     }
 
-    public static String formatPlayer(String playerName, UUID playerID) {
+    public static Component formatPlayer(String playerName, UUID playerID) {
         return resolveNameTemplate("placeholders.player", playerName, playerID);
     }
-    public static String formatSeller(String playerName, UUID playerID) {
-        return resolveNameTemplate("placeholders.seller", playerName,playerID);
+
+    public static Component formatSeller(String playerName, UUID playerID) {
+        return resolveNameTemplate("placeholders.seller", playerName, playerID);
     }
-    public static String formatBuyer(String playerName, UUID playerID) {
+
+    public static Component formatBuyer(String playerName, UUID playerID) {
         return resolveNameTemplate("placeholders.buyer", playerName, playerID);
     }
 
-
-    // substitute %player_name% with PAPI when available
-    private static String resolveNameTemplate(String templateKey, String playerName, UUID playerID) {
-        if (playerName == null) return "";
-        String template = get().getString(templateKey, "%player_name%");
-        String result = template.replace("%player_name%", playerName);
+    // substitute <player_name> with PAPI when available
+    private static Component resolveNameTemplate(String templateKey, String playerName, UUID playerID) {
+        if (playerName == null) return Component.empty();
+        String template = get().getString(templateKey);
+        String result = template == null ? "<player_name>" : template;
+        result = result.replace("<player_name>", playerName)
+                .replace("%player_name%", playerName);
 
         if (Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")) {
             OfflinePlayer target = Bukkit.getOfflinePlayer(playerID);
             result = PlaceholderAPI.setPlaceholders(target, result);
         }
 
-        result = ChatColor.translateAlternateColorCodes('&', result);
-        return adventureApi(result);
+        return deserialize(result.replace('&', '§'), resolverOf());
     }
 
-    private static String adventureApi(String input) {
-        if (!SettingManager.useAdventureAPIMessages) return input;
-        Component comp;
-        try {
-            comp = mm.deserialize(input);
-        } catch (Exception e) {
-            comp = legacy.deserialize(input);
+    private static Component deserialize(String input, TagResolver resolver) {
+        return mm.deserialize(input, resolver);
+    }
+
+    private static TagResolver resolverOf(Object... replacements) {
+        TagResolver.Builder builder = TagResolver.builder();
+        for (int i = 0; i < replacements.length; i += 2) {
+            String tag = String.valueOf(replacements[i]).toLowerCase(Locale.ROOT);
+            builder.resolver(TagResolver.resolver(tag, tagOf(tag, replacements[i + 1])));
         }
-        return legacy.serialize(comp);
+        return builder.build();
+    }
+
+    private static Tag tagOf(String tag, Object value) {
+        if (value instanceof Component component) {
+            return Tag.selfClosingInserting(component);
+        }
+        if (value instanceof Number number) {
+            double d = number.doubleValue();
+            if (tag.startsWith("price-trim")) return Tag.selfClosingInserting(StringUtils.formatPrice(d, true));
+            if (tag.startsWith("price")) return Tag.selfClosingInserting(StringUtils.formatPrice(d, false));
+            if (tag.startsWith("number")) return Tag.selfClosingInserting(StringUtils.formatNumber(d));
+            return Tag.selfClosingInserting(Component.text(value.toString()));
+        }
+        return Tag.selfClosingInserting(safeDeserialize(value.toString()));
+    }
+
+    private static Component safeDeserialize(String input) {
+        if (input == null) return Component.empty();
+        try {
+            return mm.deserialize(input);
+        } catch (Exception e) {
+            return Component.text(input);
+        }
+    }
+
+    private static Component error(String message) {
+        return mm.deserialize("<red>" + message);
+    }
+
+    private static String convertLegacyInput(String input) {
+        String result = replaceLegacyPlaceholders(input);
+        if (result.indexOf('§') == -1) return result;
+        StringBuilder sb = new StringBuilder(result.length());
+        for (int i = 0; i < result.length(); i++) {
+            char c = result.charAt(i);
+            if (c != '§') {
+                sb.append(c);
+                continue;
+            }
+            if (i + 1 >= result.length()) break;
+            char code = Character.toLowerCase(result.charAt(++i));
+            if (code == 'x') {
+                StringBuilder hex = new StringBuilder(6);
+                for (int h = 0; h < 6 && i + 2 < result.length(); h++) {
+                    i += 2;
+                    hex.append(result.charAt(i));
+                }
+                sb.append("<color:#").append(hex).append('>');
+                continue;
+            }
+            String tag = legacyCodeToTag(code);
+            if (tag != null) sb.append('<').append(tag).append('>');
+        }
+        return sb.toString();
+    }
+
+    private static String replaceLegacyPlaceholders(String input) {
+        Matcher matcher = LEGACY_PLACEHOLDER.matcher(input);
+        StringBuilder sb = new StringBuilder(input.length());
+        while (matcher.find()) {
+            String name = matcher.group(1);
+            if (KNOWN_PLACEHOLDERS.contains(name)
+                    || name.startsWith("price") || name.startsWith("number") || name.startsWith("price-trim")) {
+                matcher.appendReplacement(sb, "<" + name + ">");
+            }
+        }
+        return matcher.appendTail(sb).toString();
+    }
+
+    private static String legacyCodeToTag(char code) {
+        return switch (code) {
+            case '0' -> "black";
+            case '1' -> "dark_blue";
+            case '2' -> "dark_green";
+            case '3' -> "dark_aqua";
+            case '4' -> "dark_red";
+            case '5' -> "dark_purple";
+            case '6' -> "gold";
+            case '7' -> "gray";
+            case '8' -> "dark_gray";
+            case '9' -> "blue";
+            case 'a' -> "green";
+            case 'b' -> "aqua";
+            case 'c' -> "red";
+            case 'd' -> "light_purple";
+            case 'e' -> "yellow";
+            case 'f' -> "white";
+            case 'k' -> "obfuscated";
+            case 'l' -> "bold";
+            case 'm' -> "strikethrough";
+            case 'n' -> "underlined";
+            case 'o' -> "italic";
+            case 'r' -> "reset";
+            default -> null;
+        };
     }
 
 }

--- a/src/main/java/me/elaineqheart/auctionHouse/data/persistentStorage/local/configs/M.java
+++ b/src/main/java/me/elaineqheart/auctionHouse/data/persistentStorage/local/configs/M.java
@@ -5,6 +5,7 @@ import me.elaineqheart.auctionHouse.data.StringUtils;
 import me.elaineqheart.auctionHouse.data.persistentStorage.local.data.Config;
 import me.elaineqheart.auctionHouse.data.persistentStorage.local.data.ConfigManager;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
@@ -25,6 +26,7 @@ public class M extends Config {
 
     private static final MiniMessage mm = MiniMessage.builder()
             .preProcessor(M::convertLegacyInput)
+            .postProcessor(M::explicitItalic)
             .build();
 
     // legacy %placeholder% tokens that are rewritten to MiniMessage tags so old configs keep working
@@ -69,6 +71,14 @@ public class M extends Config {
     // parses arbitrary text (item names, admin input) through the same MiniMessage pipeline
     public static Component deserialize(String input) {
         return safeDeserialize(input);
+    }
+
+    private static Component explicitItalic(Component component) {
+        return component.style(s -> {
+            if (s.build().decoration(TextDecoration.ITALIC) == TextDecoration.State.NOT_SET) {
+                s.decoration(TextDecoration.ITALIC, TextDecoration.State.FALSE);
+            }
+        }).children(component.children().stream().map(M::explicitItalic).toList());
     }
 
     public static Component formatPlayer(String playerName, UUID playerID) {

--- a/src/main/java/me/elaineqheart/auctionHouse/data/ram/ItemManager.java
+++ b/src/main/java/me/elaineqheart/auctionHouse/data/ram/ItemManager.java
@@ -6,6 +6,7 @@ import me.elaineqheart.auctionHouse.GUI.impl.MyAuctionsGUI;
 import me.elaineqheart.auctionHouse.data.StringUtils;
 import me.elaineqheart.auctionHouse.data.persistentStorage.local.configs.M;
 import me.elaineqheart.auctionHouse.data.persistentStorage.local.data.ConfigManager;
+import net.kyori.adventure.text.Component;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
@@ -92,7 +93,7 @@ public class ItemManager {
         ItemStack item = ConfigManager.layout.getItem("locked-slot");
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        meta.setItemName(M.getFormatted("items.locked-slot.name"));
+        meta.itemName(M.getFormatted("items.locked-slot.name"));
         item.setItemMeta(meta);
         return item;
     }
@@ -100,8 +101,8 @@ public class ItemManager {
         ItemStack item = ConfigManager.layout.getItem("r");
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        meta.setItemName(M.getFormatted("items.refresh.name"));
-        meta.setLore(M.getLoreList("items.refresh.lore"));
+        meta.itemName(M.getFormatted("items.refresh.name"));
+        meta.lore(M.getLoreList("items.refresh.lore"));
         item.setItemMeta(meta);
         return item;
     }
@@ -109,8 +110,8 @@ public class ItemManager {
         ItemStack item = ConfigManager.layout.getItem("d");
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        meta.setItemName(M.getFormatted("items.my-bids.name"));
-        meta.setLore(M.getLoreList("items.my-bids.lore"));
+        meta.itemName(M.getFormatted("items.my-bids.name"));
+        meta.lore(M.getLoreList("items.my-bids.lore"));
         item.setItemMeta(meta);
         return item;
     }
@@ -118,8 +119,8 @@ public class ItemManager {
         ItemStack item = ConfigManager.layout.getItem("b");
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        meta.setItemName(M.getFormatted("items.back-main-menu.name"));
-        meta.setLore(M.getLoreList("items.back-main-menu.lore"));
+        meta.itemName(M.getFormatted("items.back-main-menu.name"));
+        meta.lore(M.getLoreList("items.back-main-menu.lore"));
         item.setItemMeta(meta);
         return item;
     }
@@ -127,8 +128,8 @@ public class ItemManager {
         ItemStack item = ConfigManager.layout.getItem("back-to-my-auctions");
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        meta.setItemName(M.getFormatted("items.back-my-auctions.name"));
-        meta.setLore(M.getLoreList("items.back-my-auctions.lore"));
+        meta.itemName(M.getFormatted("items.back-my-auctions.name"));
+        meta.lore(M.getLoreList("items.back-my-auctions.lore"));
         item.setItemMeta(meta);
         return item;
     }
@@ -136,10 +137,10 @@ public class ItemManager {
         ItemStack item = ConfigManager.layout.getItem("i");
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        meta.setItemName(M.getFormatted("items.info.name"));
+        meta.itemName(M.getFormatted("items.info.name"));
         //cast the tax value to int and then to double to avoid floating point issues
         String tax = ChatColor.GOLD + "" + (double)(int)(AuctionHouse.getInstance().getConfig().getDouble("tax") * 1000) / 10 + "%";
-        meta.setLore(M.getLoreList("items.info.lore", "%tax%", tax));
+        meta.lore(M.getLoreList("items.info.lore", "tax", tax));
         item.setItemMeta(meta);
         return item;
     }
@@ -147,8 +148,8 @@ public class ItemManager {
         ItemStack item = ConfigManager.layout.getItem("m");
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        meta.setItemName(M.getFormatted("items.my-auctions.name"));
-        meta.setLore(M.getLoreList("items.my-auctions.lore"));
+        meta.itemName(M.getFormatted("items.my-auctions.name"));
+        meta.lore(M.getLoreList("items.my-auctions.lore"));
         item.setItemMeta(meta);
         return item;
     }
@@ -156,8 +157,8 @@ public class ItemManager {
         ItemStack item = ConfigManager.layout.getItem("o");
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        meta.setItemName(M.getFormatted("items.sort-highest-price.name"));
-        meta.setLore(M.getLoreList("items.sort-highest-price.lore"));
+        meta.itemName(M.getFormatted("items.sort-highest-price.name"));
+        meta.lore(M.getLoreList("items.sort-highest-price.lore"));
         item.setItemMeta(meta);
         return item;
     }
@@ -165,8 +166,8 @@ public class ItemManager {
         ItemStack item = ConfigManager.layout.getItem("o");
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        meta.setItemName(M.getFormatted("items.sort-lowest-price.name"));
-        meta.setLore(M.getLoreList("items.sort-lowest-price.lore"));
+        meta.itemName(M.getFormatted("items.sort-lowest-price.name"));
+        meta.lore(M.getLoreList("items.sort-lowest-price.lore"));
         item.setItemMeta(meta);
         return item;
     }
@@ -174,8 +175,8 @@ public class ItemManager {
         ItemStack item = ConfigManager.layout.getItem("o");
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        meta.setItemName(M.getFormatted("items.sort-ending-soon.name"));
-        meta.setLore(M.getLoreList("items.sort-ending-soon.lore"));
+        meta.itemName(M.getFormatted("items.sort-ending-soon.name"));
+        meta.lore(M.getLoreList("items.sort-ending-soon.lore"));
         item.setItemMeta(meta);
         return item;
     }
@@ -183,8 +184,8 @@ public class ItemManager {
         ItemStack item = ConfigManager.layout.getItem("o");
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        meta.setItemName(M.getFormatted("items.sort-alphabetical.name"));
-        meta.setLore(M.getLoreList("items.sort-alphabetical.lore"));
+        meta.itemName(M.getFormatted("items.sort-alphabetical.name"));
+        meta.lore(M.getLoreList("items.sort-alphabetical.lore"));
         item.setItemMeta(meta);
         return item;
     }
@@ -204,8 +205,8 @@ public class ItemManager {
         ItemStack item = ConfigManager.layout.getItem("o");
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        meta.setItemName(M.getFormatted("items.my-sort-all.name"));
-        meta.setLore(M.getLoreList("items.my-sort-all.lore"));
+        meta.itemName(M.getFormatted("items.my-sort-all.name"));
+        meta.lore(M.getLoreList("items.my-sort-all.lore"));
         item.setItemMeta(meta);
         return item;
     }
@@ -213,8 +214,8 @@ public class ItemManager {
         ItemStack item = ConfigManager.layout.getItem("o");
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        meta.setItemName(M.getFormatted("items.my-sort-sold.name"));
-        meta.setLore(M.getLoreList("items.my-sort-sold.lore"));
+        meta.itemName(M.getFormatted("items.my-sort-sold.name"));
+        meta.lore(M.getLoreList("items.my-sort-sold.lore"));
         item.setItemMeta(meta);
         return item;
     }
@@ -222,8 +223,8 @@ public class ItemManager {
         ItemStack item = ConfigManager.layout.getItem("o");
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        meta.setItemName(M.getFormatted("items.my-sort-expired.name"));
-        meta.setLore(M.getLoreList("items.my-sort-expired.lore"));
+        meta.itemName(M.getFormatted("items.my-sort-expired.name"));
+        meta.lore(M.getLoreList("items.my-sort-expired.lore"));
         item.setItemMeta(meta);
         return item;
     }
@@ -231,8 +232,8 @@ public class ItemManager {
         ItemStack item = ConfigManager.layout.getItem("o");
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        meta.setItemName(M.getFormatted("items.my-sort-active.name"));
-        meta.setLore(M.getLoreList("items.my-sort-active.lore"));
+        meta.itemName(M.getFormatted("items.my-sort-active.name"));
+        meta.lore(M.getLoreList("items.my-sort-active.lore"));
         item.setItemMeta(meta);
         return item;
     }
@@ -249,7 +250,7 @@ public class ItemManager {
         ItemStack item = ConfigManager.layout.getItem("cancel");
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        meta.setItemName(M.getFormatted("items.cancel.name"));
+        meta.itemName(M.getFormatted("items.cancel.name"));
         item.setItemMeta(meta);
         return item;
     }
@@ -257,8 +258,8 @@ public class ItemManager {
         ItemStack item = ConfigManager.layout.getItem("collect-expired-item");
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        meta.setItemName(M.getFormatted("items.collect-expired.name"));
-        meta.setLore(M.getLoreList("items.collect-expired.lore"));
+        meta.itemName(M.getFormatted("items.collect-expired.name"));
+        meta.lore(M.getLoreList("items.collect-expired.lore"));
         item.setItemMeta(meta);
         return item;
     }
@@ -266,8 +267,8 @@ public class ItemManager {
         ItemStack item = ConfigManager.layout.getItem("cancel-auction");
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        meta.setItemName(M.getFormatted("items.cancel-auction.name"));
-        meta.setLore(M.getLoreList("items.cancel-auction.lore"));
+        meta.itemName(M.getFormatted("items.cancel-auction.name"));
+        meta.lore(M.getLoreList("items.cancel-auction.lore"));
         item.setItemMeta(meta);
         return item;
     }
@@ -275,8 +276,8 @@ public class ItemManager {
         ItemStack item = ConfigManager.layout.getItem("cancel-auction");
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        meta.setItemName(M.getFormatted("items.cancel-bid-auction.name"));
-        meta.setLore(M.getLoreList("items.cancel-bid-auction.lore"));
+        meta.itemName(M.getFormatted("items.cancel-bid-auction.name"));
+        meta.lore(M.getLoreList("items.cancel-bid-auction.lore"));
         item.setItemMeta(meta);
         return item;
     }
@@ -284,8 +285,8 @@ public class ItemManager {
         ItemStack item = ConfigManager.layout.getItem("command-block-info");
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        meta.setItemName(M.getFormatted("items.admin-info.name"));
-        meta.setLore(M.getLoreList("items.admin-info.lore"));
+        meta.itemName(M.getFormatted("items.admin-info.name"));
+        meta.lore(M.getLoreList("items.admin-info.lore"));
         item.setItemMeta(meta);
         return item;
     }
@@ -293,8 +294,8 @@ public class ItemManager {
         ItemStack item = ConfigManager.layout.getItem("admin-cancel-auction");
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        meta.setItemName(M.getFormatted("items.admin-cancel-auction.name"));
-        meta.setLore(M.getLoreList("items.admin-cancel-auction.lore"));
+        meta.itemName(M.getFormatted("items.admin-cancel-auction.name"));
+        meta.lore(M.getLoreList("items.admin-cancel-auction.lore"));
         item.setItemMeta(meta);
         return item;
     }
@@ -302,8 +303,8 @@ public class ItemManager {
         ItemStack item = ConfigManager.layout.getItem("admin-expire-auction");
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        meta.setItemName(M.getFormatted("items.admin-expire-auction.name"));
-        meta.setLore(M.getLoreList("items.admin-expire-auction.lore"));
+        meta.itemName(M.getFormatted("items.admin-expire-auction.name"));
+        meta.lore(M.getLoreList("items.admin-expire-auction.lore"));
         item.setItemMeta(meta);
         return item;
     }
@@ -311,7 +312,7 @@ public class ItemManager {
         ItemStack item = ConfigManager.layout.getItem("confirm");
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        meta.setItemName(M.getFormatted("items.confirm.name"));
+        meta.itemName(M.getFormatted("items.confirm.name"));
         item.setItemMeta(meta);
         return item;
     }
@@ -319,8 +320,8 @@ public class ItemManager {
         ItemStack item = ConfigManager.layout.getItem("choose-item-buy-amount");
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        meta.setItemName(M.getFormatted("items.choose-item-buy-amount.name"));
-        meta.setLore(M.getLoreList("items.choose-item-buy-amount.lore"));
+        meta.itemName(M.getFormatted("items.choose-item-buy-amount.name"));
+        meta.lore(M.getLoreList("items.choose-item-buy-amount.lore"));
         item.setItemMeta(meta);
         return item;
     }
@@ -328,7 +329,7 @@ public class ItemManager {
         ItemStack item = ConfigManager.layout.getItem("loading");
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        meta.setItemName(M.getFormatted("items.loading.name"));
+        meta.itemName(M.getFormatted("items.loading.name"));
         item.setItemMeta(meta);
         return item;
     }
@@ -337,7 +338,7 @@ public class ItemManager {
         ItemStack item = ConfigManager.layout.getItem("dirt");
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        meta.setItemName(M.getFormatted("items.deleted.name"));
+        meta.itemName(M.getFormatted("items.deleted.name"));
         item.setItemMeta(meta);
         return item;
     }
@@ -345,23 +346,26 @@ public class ItemManager {
         ItemStack item = note.getItem();
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        List<String> lore = meta.getLore();
+        List<Component> lore = meta.lore();
         if (lore==null) lore = new ArrayList<>();
         if (isShulkerBox(item)) {
             lore.addAll(M.getLoreList("items.auction.lore.shulker-preview"));
         }
         if (!note.isBIDAuction()) {
-            lore.addAll(M.getLoreList("items.auction.lore.default", ownAuction ? note.getPrice() : note.getCurrentPrice(),
-                    "%seller%", M.formatSeller(note.getPlayerName(), note.getPlayerUUID())));
+            lore.addAll(M.getLoreList("items.auction.lore.default",
+                    "price", ownAuction ? note.getPrice() : note.getCurrentPrice(),
+                    "seller", M.formatSeller(note.getPlayerName(), note.getPlayerUUID())));
         } else {
             if (note.getBidHistoryList().isEmpty()) {
-                lore.addAll(M.getLoreList("items.auction.lore.default-starting-bid", note.getPrice(),
-                        "%seller%", M.formatSeller(note.getPlayerName(), note.getPlayerUUID())));
+                lore.addAll(M.getLoreList("items.auction.lore.default-starting-bid",
+                        "price", note.getPrice(),
+                        "seller", M.formatSeller(note.getPlayerName(), note.getPlayerUUID())));
             } else {
-                lore.addAll(M.getLoreList("items.auction.lore.default-bid", note.getPrice(),
-                        "%seller%", M.formatSeller(note.getPlayerName(), note.getPlayerUUID()),
-                        "%amountOfBids%", String.valueOf(note.getBidHistoryList().size()),
-                        "%buyer%", M.formatBuyer(note.getLastBidderName(), note.getLastBidder())));
+                lore.addAll(M.getLoreList("items.auction.lore.default-bid",
+                        "price", note.getPrice(),
+                        "seller", M.formatSeller(note.getPlayerName(), note.getPlayerUUID()),
+                        "amountOfBids", String.valueOf(note.getBidHistoryList().size()),
+                        "buyer", M.formatBuyer(note.getLastBidderName(), note.getLastBidder())));
             }
         }
         if (Objects.equals(note.getPlayerUUID(),p.getUniqueId())) {
@@ -371,15 +375,15 @@ public class ItemManager {
         if (note.isSold() && note.isTheoreticallyOnAuction()) {
             if (ownAuction) {
                 lore.addAll(M.getLoreList("items.auction.lore.partially-sold",
-                        "%sold%", String.valueOf(note.getItem().getAmount() - note.getPartiallySoldAmountLeft()),
-                        "%total%", String.valueOf(note.getItem().getAmount()),
-                        "%buyer%", M.formatBuyer(note.getBuyerName(), note.getBuyerUUID())));
+                        "sold", String.valueOf(note.getItem().getAmount() - note.getPartiallySoldAmountLeft()),
+                        "total", String.valueOf(note.getItem().getAmount()),
+                        "buyer", M.formatBuyer(note.getBuyerName(), note.getBuyerUUID())));
             } else {
                 item.setAmount(note.getPartiallySoldAmountLeft());
             }
             if (!note.isExpired()) {
                 lore.addAll(M.getLoreList("items.auction.lore.active",
-                        "%time%", StringUtils.getTime(note.getTimeLeft(), true)));
+                        "time", StringUtils.getTime(note.getTimeLeft(), true)));
             } else {
                 addAdminMessageOrExpired(lore, note);
             }
@@ -389,22 +393,22 @@ public class ItemManager {
             addAdminMessageOrExpired(lore, note);
         } else if (note.isSold() && !note.isTheoreticallyOnAuction()) {
             lore.addAll(M.getLoreList("items.auction.lore.sold",
-                    "%buyer%", M.formatBuyer(note.getBuyerName(), note.getBuyerUUID())));
+                    "buyer", M.formatBuyer(note.getBuyerName(), note.getBuyerUUID())));
         } else if (note.isOnWaitingList()) {
             lore.addAll(M.getLoreList("items.auction.lore.waiting-list",
-                    "%time%", StringUtils.getTime(
+                    "time", StringUtils.getTime(
                             note.getTimeLeft() - ConfigManager.permissions.getAuctionDuration(p, note.isBIDAuction()), true
                     )));
         } else {
             lore.addAll(M.getLoreList("items.auction.lore.active",
-                    "%time%", StringUtils.getTime(note.getTimeLeft(), true)));
+                    "time", StringUtils.getTime(note.getTimeLeft(), true)));
         }
 
-        meta.setLore(lore);
+        meta.lore(lore);
         item.setItemMeta(meta);
         return item;
     }
-    private static void addAdminMessageOrExpired(List<String> lore, ItemNote note) {
+    private static void addAdminMessageOrExpired(List<Component> lore, ItemNote note) {
         if (note.getAdminMessage()!=null && !note.getAdminMessage().isEmpty()) {
             if (note.getItem().equals(createDirt())) {
                 lore.addAll(M.getLoreList("items.auction.lore.admin-deleted"));
@@ -412,7 +416,7 @@ public class ItemManager {
                 lore.addAll(M.getLoreList("items.auction.lore.admin-expired"));
             }
             lore.addAll(M.getLoreList("items.auction.lore.admin-message",
-                    "%reason%", note.getAdminMessage()));
+                    "reason", note.getAdminMessage()));
         } else if (!note.isSold() && !note.isBIDAuction() || !note.hasBidHistory() && note.isBIDAuction()) {
             lore.addAll(M.getLoreList("items.auction.lore.expired"));
         }
@@ -421,26 +425,27 @@ public class ItemManager {
         ItemStack item = note.getItem();
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        List<String> lore = meta.getLore();
+        List<Component> lore = meta.lore();
         if (lore == null) lore = new ArrayList<>();
-        lore.addAll(M.getLoreList("items.auction.lore.default", note.getSoldPrice(),
-                "%seller%", M.formatSeller(note.getPlayerName(), note.getPlayerUUID())));
+        lore.addAll(M.getLoreList("items.auction.lore.default",
+                "price", note.getSoldPrice(),
+                "seller", M.formatSeller(note.getPlayerName(), note.getPlayerUUID())));
         lore.addAll(M.getLoreList("items.auction.lore.own-auction"));
         lore.addAll(M.getLoreList("items.auction.lore.sold",
-                "%buyer%", M.formatBuyer(note.getBuyerName(), note.getBuyerUUID())));
+                "buyer", M.formatBuyer(note.getBuyerName(), note.getBuyerUUID())));
         item.setAmount(item.getAmount() - note.getPartiallySoldAmountLeft());
 
-        meta.setLore(lore);
+        meta.lore(lore);
         item.setItemMeta(meta);
         return item;
     }
     public static ItemStack createBuyingItemDisplay(ItemStack item) {
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        List<String> lore = meta.getLore();
+        List<Component> lore = meta.lore();
         if(lore==null) lore = new ArrayList<>();
         lore.addAll(M.getLoreList("items.auction.lore.buying-item"));
-        meta.setLore(lore);
+        meta.lore(lore);
         item.setItemMeta(meta);
         return item;
     }
@@ -448,12 +453,13 @@ public class ItemManager {
         ItemStack item = note.getItem();
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        List<String> lore = meta.getLore();
+        List<Component> lore = meta.lore();
         if(lore==null) lore = new ArrayList<>();
-        lore.addAll(M.getLoreList("items.admin-expire-item.lore", note.getPrice(),
-                "%seller%", M.formatSeller(note.getPlayerName(), note.getPlayerUUID()),
-                "%reason%", reason));
-        meta.setLore(lore);
+        lore.addAll(M.getLoreList("items.admin-expire-item.lore",
+                "price", note.getPrice(),
+                "seller", M.formatSeller(note.getPlayerName(), note.getPlayerUUID()),
+                "reason", reason));
+        meta.lore(lore);
         item.setItemMeta(meta);
         return item;
     }
@@ -461,12 +467,13 @@ public class ItemManager {
         ItemStack item = createDirt();
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        List<String> lore = meta.getLore();
+        List<Component> lore = meta.lore();
         if(lore==null) lore = new ArrayList<>();
-        lore.addAll(M.getLoreList("items.admin-delete-item.lore", note.getPrice(),
-                "%seller%", M.formatSeller(note.getPlayerName(), note.getPlayerUUID()),
-                "%reason%", reason));
-        meta.setLore(lore);
+        lore.addAll(M.getLoreList("items.admin-delete-item.lore",
+                "price", note.getPrice(),
+                "seller", M.formatSeller(note.getPlayerName(), note.getPlayerUUID()),
+                "reason", reason));
+        meta.lore(lore);
         item.setItemMeta(meta);
         return item;
     }
@@ -474,8 +481,8 @@ public class ItemManager {
         ItemStack item = ConfigManager.layout.getItem("turtle-scute-confirm");
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        meta.setItemName(M.getFormatted("items.buy-item.name"));
-        meta.setLore(M.getLoreList("items.buy-item.lore", price));
+        meta.itemName(M.getFormatted("items.buy-item.name"));
+        meta.lore(M.getLoreList("items.buy-item.lore", "price", price));
         item.setItemMeta(meta);
         return item;
     }
@@ -483,8 +490,8 @@ public class ItemManager {
         ItemStack item = ConfigManager.layout.getItem("cannot-afford");
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        meta.setItemName(M.getFormatted("items.not-enough-money.name"));
-        meta.setLore(M.getLoreList("items.not-enough-money.lore", price));
+        meta.itemName(M.getFormatted("items.not-enough-money.name"));
+        meta.lore(M.getLoreList("items.not-enough-money.lore", "price", price));
         item.setItemMeta(meta);
         return item;
     }
@@ -492,8 +499,8 @@ public class ItemManager {
         ItemStack item = ConfigManager.layout.getItem("confirm");
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        meta.setItemName(M.getFormatted("items.confirm-buy.name"));
-        meta.setLore(M.getLoreList("items.confirm-buy.lore", price));
+        meta.itemName(M.getFormatted("items.confirm-buy.name"));
+        meta.lore(M.getLoreList("items.confirm-buy.lore", "price", price));
         item.setItemMeta(meta);
         return item;
     }
@@ -501,8 +508,8 @@ public class ItemManager {
         ItemStack item = ConfigManager.layout.getItem("collect-sold-item");
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        meta.setItemName(M.getFormatted("items.collect-sold.name"));
-        meta.setLore(M.getLoreList("items.collect-sold.lore", price));
+        meta.itemName(M.getFormatted("items.collect-sold.name"));
+        meta.lore(M.getLoreList("items.collect-sold.lore", "price", price));
         item.setItemMeta(meta);
         return item;
     }
@@ -510,22 +517,23 @@ public class ItemManager {
         ItemStack item = ConfigManager.layout.getItem("bid-history");
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        meta.setItemName(M.getFormatted("items.bid-history.name"));
-        List<String> lore = meta.getLore();
+        meta.itemName(M.getFormatted("items.bid-history.name"));
+        List<Component> lore = meta.lore();
         if(lore==null) lore = new ArrayList<>();
         lore.addAll(M.getLoreList("items.bid-history.lore",
-                "%amountOfBids%", String.valueOf(bidHistory.size())));
+                "amountOfBids", String.valueOf(bidHistory.size())));
         for(int i = 0; i < Math.min(bidHistory.size(), 6); i++) {
             Bid bid = bidHistory.get(bidHistory.size()-1-i);
-            lore.addAll(M.getLoreList("items.bid-history.bid", bid.getPrice(),
-                    "%player%", M.formatPlayer(bid.getPlayerName(), bid.getPlayerID()),
-                    "%time%", bid.getTimeAgo()));
+            lore.addAll(M.getLoreList("items.bid-history.bid",
+                    "price", bid.getPrice(),
+                    "player", M.formatPlayer(bid.getPlayerName(), bid.getPlayerID()),
+                    "time", bid.getTimeAgo()));
         }
         if(bidHistory.size() - 6 > 0) {
             lore.addAll(M.getLoreList("items.bid-history.more",
-                    "%amount%", String.valueOf(bidHistory.size()-6)));
+                    "amount", String.valueOf(bidHistory.size()-6)));
         }
-        meta.setLore(lore);
+        meta.lore(lore);
         item.setItemMeta(meta);
         return item;
     }
@@ -533,8 +541,8 @@ public class ItemManager {
         ItemStack item = ConfigManager.layout.getItem("bid-explanation");
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        meta.setItemName(M.getFormatted("items.bid-explanation.name", amount));
-        meta.setLore(M.getLoreList("items.bid-explanation.lore", amount));
+        meta.itemName(M.getFormatted("items.bid-explanation.name", "price", amount));
+        meta.lore(M.getLoreList("items.bid-explanation.lore", "price", amount));
         item.setItemMeta(meta);
         return item;
     }
@@ -543,13 +551,13 @@ public class ItemManager {
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
         if(previousBid == 0) {
-            meta.setItemName(M.getFormatted("items.submit-bid.name", amount));
-            meta.setLore(M.getLoreList("items.submit-bid.lore", amount));
+            meta.itemName(M.getFormatted("items.submit-bid.name", "price", amount));
+            meta.lore(M.getLoreList("items.submit-bid.lore", "price", amount));
         } else {
-            meta.setItemName(M.getFormatted("items.submit-another-bid.name", amount));
-            List<String> lore = M.getLoreList("items.submit-another-bid.lore");
-            lore.replaceAll(s -> M.replace(s, amount, previousBid, amount-previousBid));
-            meta.setLore(lore);
+            meta.itemName(M.getFormatted("items.submit-another-bid.name", "price", amount));
+            List<Component> lore = M.getLoreList("items.submit-another-bid.lore",
+                    "price", amount, "price2", previousBid, "price3", amount - previousBid);
+            meta.lore(lore);
         }
         item.setItemMeta(meta);
         return item;
@@ -558,8 +566,8 @@ public class ItemManager {
         ItemStack item = ConfigManager.layout.getItem("own-bid");
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        meta.setItemName(M.getFormatted("items.own-bid.name", amount));
-        meta.setLore(M.getLoreList("items.own-bid.lore", amount));
+        meta.itemName(M.getFormatted("items.own-bid.name", "price", amount));
+        meta.lore(M.getLoreList("items.own-bid.lore", "price", amount));
         item.setItemMeta(meta);
         return item;
     }
@@ -567,8 +575,8 @@ public class ItemManager {
         ItemStack item = ConfigManager.layout.getItem("cannot-afford-bid");
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        meta.setItemName(M.getFormatted("items.cannot-afford-bid.name", amount));
-        meta.setLore(M.getLoreList("items.cannot-afford-bid.lore", amount));
+        meta.itemName(M.getFormatted("items.cannot-afford-bid.name", "price", amount));
+        meta.lore(M.getLoreList("items.cannot-afford-bid.lore", "price", amount));
         item.setItemMeta(meta);
         return item;
     }
@@ -576,10 +584,10 @@ public class ItemManager {
         ItemStack item = ConfigManager.layout.getItem("top-bid");
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        meta.setItemName(M.getFormatted("items.top-bid.name", amount));
-        List<String> lore = M.getLoreList("items.top-bid.lore");
-        lore.replaceAll(s -> M.replace(s, amount, newBid));
-        meta.setLore(lore);
+        meta.itemName(M.getFormatted("items.top-bid.name", "price", amount));
+        List<Component> lore = M.getLoreList("items.top-bid.lore",
+                "price", amount, "price2", newBid);
+        meta.lore(lore);
         item.setItemMeta(meta);
         return item;
     }
@@ -591,12 +599,12 @@ public class ItemManager {
         };
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        meta.setItemName(M.getFormatted(switch(binFilter) {
+        meta.itemName(M.getFormatted(switch(binFilter) {
             case ALL -> "items.bin-filter-all.name";
             case BIN_ONLY -> "items.bin-filter-bin.name";
             case AUCTIONS_ONLY -> "items.bin-filter-auctions.name";
         }));
-        meta.setLore(M.getLoreList(switch(binFilter) {
+        meta.lore(M.getLoreList(switch(binFilter) {
             case ALL -> "items.bin-filter-all.lore";
             case BIN_ONLY -> "items.bin-filter-bin.lore";
             case AUCTIONS_ONLY -> "items.bin-filter-auctions.lore";
@@ -608,8 +616,8 @@ public class ItemManager {
         ItemStack item = ConfigManager.layout.getItem("collect-auction");
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        meta.setItemName(M.getFormatted("items.collect-auction.name"));
-        meta.setLore(M.getLoreList("items.collect-auction.lore", note.getBidHistoryList().getLast().getPrice()));
+        meta.itemName(M.getFormatted("items.collect-auction.name"));
+        meta.lore(M.getLoreList("items.collect-auction.lore", "price", note.getBidHistoryList().getLast().getPrice()));
         item.setItemMeta(meta);
         return item;
     }
@@ -617,11 +625,12 @@ public class ItemManager {
         ItemStack item = ConfigManager.layout.getItem("collect-coins");
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        meta.setItemName(M.getFormatted("items.collect-coins.name"));
-        List<String> lore = M.getLoreList("items.collect-coins.lore", note.getBidHistoryList().getLast().getPrice(),
-                "%player%", M.formatPlayer(note.getLastBidderName(), note.getLastBidder()));
-        lore.replaceAll(s -> M.replace(s, note.getBidHistoryList().getLast().getPrice(), note.getBid(p)));
-        meta.setLore(lore);
+        meta.itemName(M.getFormatted("items.collect-coins.name"));
+        List<Component> lore = M.getLoreList("items.collect-coins.lore",
+                "price", note.getBidHistoryList().getLast().getPrice(),
+                "price2", note.getBid(p),
+                "player", M.formatPlayer(note.getLastBidderName(), note.getLastBidder()));
+        meta.lore(lore);
         item.setItemMeta(meta);
         return item;
     }

--- a/src/main/java/me/elaineqheart/auctionHouse/listeners/PlayerJoinCollectListener.java
+++ b/src/main/java/me/elaineqheart/auctionHouse/listeners/PlayerJoinCollectListener.java
@@ -6,6 +6,7 @@ import me.elaineqheart.auctionHouse.data.persistentStorage.local.SettingManager;
 import me.elaineqheart.auctionHouse.data.persistentStorage.local.configs.M;
 import me.elaineqheart.auctionHouse.data.ram.AuctionHouseStorage;
 import me.elaineqheart.auctionHouse.data.ram.ItemNote;
+import net.kyori.adventure.text.Component;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -28,10 +29,11 @@ public class PlayerJoinCollectListener implements Listener {
     public static void sell(ItemNote note, Player p) {
         if (!note.isSold() && !(note.isBIDAuction() && note.hasBidHistory() && note.isExpired())) return;
         int amount = note.getItem().getAmount() - note.getPartiallySoldAmountLeft();
-        String message = M.getFormatted("chat.sold-message.auto-collect", note.getSoldPrice(),
-                "%buyer%", M.formatBuyer(note.getBuyerName(), note.getBuyerUUID()),
-                "%item%", note.getItemName(),
-                "%amount%", String.valueOf(amount));
+        Component message = M.getFormatted("chat.sold-message.auto-collect",
+                "price", note.getSoldPrice(),
+                "buyer", M.formatBuyer(note.getBuyerName(), note.getBuyerUUID()),
+                "item", note.getItemName(),
+                "amount", String.valueOf(amount));
         boolean success = CollectSoldItemGUI.collect(p, note.getNoteID(), amount, note.getSoldPrice());
         if (!success || !p.isOnline()) return;
         if (SettingManager.soldMessageEnabled) p.sendMessage(message);

--- a/src/main/java/me/elaineqheart/auctionHouse/world/displays/UpdateDisplay.java
+++ b/src/main/java/me/elaineqheart/auctionHouse/world/displays/UpdateDisplay.java
@@ -9,6 +9,8 @@ import me.elaineqheart.auctionHouse.data.persistentStorage.local.data.ConfigMana
 import me.elaineqheart.auctionHouse.data.ram.AhConfiguration;
 import me.elaineqheart.auctionHouse.data.ram.AuctionHouseStorage;
 import me.elaineqheart.auctionHouse.data.ram.ItemNote;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.*;
 import org.bukkit.block.Sign;
 import org.bukkit.block.sign.Side;
@@ -98,10 +100,10 @@ public class UpdateDisplay implements Runnable {
 
         String time = StringUtils.getTimeTrimmed(note.getTimeLeft());
         for (Sign sign : signs) {
-            sign.getSide(Side.FRONT).setLine(0, M.getFormatted("world.displays.line-0", note.getPrice(), "%time%", time));
-            sign.getSide(Side.FRONT).setLine(1, M.getFormatted("world.displays.line-1", note.getPrice(), "%time%", time));
-            sign.getSide(Side.FRONT).setLine(2, M.getFormatted("world.displays.line-2", note.getPrice(), "%time%", time));
-            sign.getSide(Side.FRONT).setLine(3, M.getFormatted("world.displays.line-3", note.getPrice(), "%time%", time));
+            sign.getSide(Side.FRONT).line(0, M.getFormatted("world.displays.line-0", "price-trim", note.getPrice()));
+            sign.getSide(Side.FRONT).line(1, M.getFormatted("world.displays.line-1", "price", note.getPrice(), "time", time));
+            sign.getSide(Side.FRONT).line(2, M.getFormatted("world.displays.line-2", "price", note.getPrice(), "time", time));
+            sign.getSide(Side.FRONT).line(3, M.getFormatted("world.displays.line-3", "price", note.getPrice(), "time", time));
             sign.update(true, false);
         }
     }
@@ -157,12 +159,17 @@ public class UpdateDisplay implements Runnable {
             data.textUUID = data.text.getUniqueId();
         }
 
+        Component byPlayer = M.getFormatted("world.displays.by-player", "player", playerName);
         if (data.sortType.equals("highest_price")) {
-            data.text.setText(ChatColor.YELLOW + "#" + data.rank + " " + ChatColor.RESET + itemName + ChatColor.GRAY + "\n" +
-                    M.getFormatted("world.displays.by-player", "%player%", playerName));
+            data.text.text(Component.text("#" + data.rank + " ", NamedTextColor.YELLOW)
+                    .append(M.deserialize(itemName))
+                    .append(Component.text("\n", NamedTextColor.GRAY))
+                    .append(byPlayer));
         } else if (data.sortType.equals("ending_soon")) {
-            data.text.setText(ChatColor.GREEN + "#" + data.rank + " " + ChatColor.RESET + itemName + ChatColor.GRAY + "\n" +
-                    M.getFormatted("world.displays.by-player", "%player%", playerName));
+            data.text.text(Component.text("#" + data.rank + " ", NamedTextColor.GREEN)
+                    .append(M.deserialize(itemName))
+                    .append(Component.text("\n", NamedTextColor.GRAY))
+                    .append(byPlayer));
         }
         return reload;
     }

--- a/src/main/java/me/elaineqheart/auctionHouse/world/npc/NPCManager.java
+++ b/src/main/java/me/elaineqheart/auctionHouse/world/npc/NPCManager.java
@@ -46,7 +46,7 @@ public class NPCManager {
         npc.setVillagerType(Villager.Type.JUNGLE);
         npc.setAdult();
         npc.setCanPickupItems(false);
-        npc.setCustomName(M.getFormatted("world.npc"));
+        npc.customName(M.getFormatted("world.npc"));
         npc.setCustomNameVisible(true);
         npc.setCollidable(false);
         npc.setGravity(false);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -17,4 +17,3 @@ min-bid: 1                                  # the minimum bid price
 max-bid: -1                                 # limit the bid price; set to -1 to disable
 last-bid-extra-time: 60                     # if the auction time is less than this when a bid is placed, it's set to this
 bid-increase-percent: 25                    # how much each bid has to increase at least
-use-adventure-text-minimessages: true       # support for miniMessages like <yellow> in messages.yml

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -1,85 +1,73 @@
-# color codes:
-# §0: Black
-# §1: Dark Blue
-# §2: Dark Green
-# §3: Dark Aqua
-# §4: Dark Red
-# §5: Dark Purple
-# §6: Gold
-# §7: Gray
-# §8: Dark Gray
-# §9: Blue
-# §a: Green
-# §b: Aqua
-# §c: Red
-# §d: Light Purple
-# §e: Yellow
-# §f: White
-
-# §k obfuscated
-# §l bold
-# §m strikethrough
-# §n underline
-# §o italic
-# §r reset
+# MiniMessage format:
+# https://docs.advntr.dev/minimessage/format.html
+#
+# Colors:
+# <black> <dark_blue> <dark_green> <dark_aqua> <dark_red> <dark_purple>
+# <gold> <gray> <dark_gray> <blue> <green> <aqua> <red> <light_purple>
+# <yellow> <white>
+#
+# Formats:
+# <obfuscated> <bold> <strikethrough> <underlined> <italic> <reset>
+# <color:#RRGGBB> for hex colors
+#
 # &n new line
 
 # chat messages from the auction house
 chat:
-  already-sold: "§cERROR! This item has already been sold!"
-  already-sold2: "§cThis item has already been sold!"
-  already-sold3: "§cAnother player already placed a bid!"
-  non-existent: "§cERROR! This item has been removed!"
-  non-existent2: "§cThis item has been removed!"
-  not-enough-money: "§cYou don't have enough money to buy this item!"
-  expired: "§cThe item is no longer on auction!"
-  inventory-full: "§cYour inventory is full!
+  already-sold: "<red>ERROR! This item has already been sold!"
+  already-sold2: "<red>This item has already been sold!"
+  already-sold3: "<red>Another player already placed a bid!"
+  non-existent: "<red>ERROR! This item has been removed!"
+  non-existent2: "<red>This item has been removed!"
+  not-enough-money: "<red>You don't have enough money to buy this item!"
+  expired: "<red>The item is no longer on auction!"
+  inventory-full: "<red>Your inventory is full!
     &nPlease empty a slot in order to take the item!"
-  admin-expire-auction: "§b-------------------------------------------------
-    &n§aYou successfully expired the auction
-    &n§rReason: %reason%
-    &n§b-------------------------------------------------"
-  admin-delete-auction: "§b-------------------------------------------------
-    &n§aYou successfully deleted the auction
-    &n§rReason: %reason%
-    &n§b-------------------------------------------------"
-  expired-auction-by-admin: "§4-------------------------------------------------
-    &n§cYour auction was expired by a moderator
-    &n§7Reason: %reason%
-    &n§4-------------------------------------------------"
-  deleted-auction-by-admin: "§4-------------------------------------------------
-    &n§cYour auction was deleted by a moderator
-    &n§7Reason: %reason%
-    &n§4-------------------------------------------------"
+  admin-expire-auction: "<aqua>-------------------------------------------------
+    &n<green>You successfully expired the auction
+    &n<reset>Reason: <reason>
+    &n<aqua>-------------------------------------------------"
+  admin-delete-auction: "<aqua>-------------------------------------------------
+    &n<green>You successfully deleted the auction
+    &n<reset>Reason: <reason>
+    &n<aqua>-------------------------------------------------"
+  expired-auction-by-admin: "<dark_red>-------------------------------------------------
+    &n<red>Your auction was expired by a moderator
+    &n<gray>Reason: <reason>
+    &n<dark_red>-------------------------------------------------"
+  deleted-auction-by-admin: "<dark_red>-------------------------------------------------
+    &n<red>Your auction was deleted by a moderator
+    &n<gray>Reason: <reason>
+    &n<dark_red>-------------------------------------------------"
   own-auction: "This is your own auction! You cannot buy it."
-  auction-canceled: "§b-------------------------------------------------
-    &n§eYour auction was canceled!
-    &n§b-------------------------------------------------"
-  collect-sold-auction: "§b-------------------------------------------------
-    &n§eYou collected an auction for %price%!
-    &n§b-------------------------------------------------"
-  purchase-auction: "§b-------------------------------------------------
-    &n§eYou purchased §r%item%§e from §7%seller%§e's auction
-    &n§b-------------------------------------------------"
+  auction-canceled: "<aqua>-------------------------------------------------
+    &n<yellow>Your auction was canceled!
+    &n<aqua>-------------------------------------------------"
+  collect-sold-auction: "<aqua>-------------------------------------------------
+    &n<yellow>You collected an auction for <price>!
+    &n<aqua>-------------------------------------------------"
+  purchase-auction: "<aqua>-------------------------------------------------
+    &n<yellow>You purchased <reset><item><yellow> from <gray><seller><yellow>'s auction
+    &n<aqua>-------------------------------------------------"
   sold-message:
-    prefix: "§6[Auction] §7%buyer%§e bought §r%item%§e for %price%"
-    interaction: " §f§l[CLICK]"
-    auto-collect: "§6[Auction] §7%buyer%§e bought §r%item%§e! §6+%price%"
-  auction-announcement: "§6[Auction] §7%player%§e is selling §r%item%§e x%amount% for %price%"
-  bid-announcement: "§6[Auction] §7%player%§e is auctioning §r%item%§e x%amount% for %price%"
-  invalid-amount: "§cThat is not a valid amount!"
-  placed-bid: "§eBid of %price%§e placed for §r%item%§e!"
+    prefix: "<gold>[Auction] <gray><buyer><yellow> bought <reset><item><yellow> for <price>"
+    interaction: " <white><bold>[CLICK]"
+    auto-collect: "<gold>[Auction] <gray><buyer><yellow> bought <reset><item><yellow>! <gold>+<price>"
+  auction-announcement: "<gold>[Auction] <gray><player><yellow> is selling <reset><item><yellow> x<amount> for <price>"
+  bid-announcement: "<gold>[Auction] <gray><player><yellow> is auctioning <reset><item><yellow> x<amount> for <price>"
+  invalid-amount: "<red>That is not a valid amount!"
+  placed-bid: "<yellow>Bid of <price><yellow> placed for <reset><item><yellow>!"
   outbid:
-    prefix: "§6[Auction] §7%player%§e outbid you by %price%§e for §r%item%§e"
-    interaction: "§f§l[CLICK]"
-  already-top-bid: "§aYou already have the top bid on this auction!"
-  claim-auction: "§b-------------------------------------------------
-    &n§eYou claimed §r%item%§e from §7%seller%§e's auction
-    &n§b-------------------------------------------------"
-  collect-coins: "§b-------------------------------------------------
-    &n§eYou collected %price%§e back from an auction
-    &n§b-------------------------------------------------"
-  input-listener: "§e%request%. Please type your input in chat:"
+    prefix: "<gold>[Auction] <gray><player><yellow> outbid you by <price><yellow> for <reset><item><yellow>"
+    interaction: "<white><bold>[CLICK]"
+  already-top-bid: "<green>You already have the top bid on this auction!"
+  claim-auction: "<aqua>-------------------------------------------------
+    &n<yellow>You claimed <reset><item><yellow> from <gray><seller><yellow>'s auction
+    &n<aqua>-------------------------------------------------"
+  collect-coins: "<aqua>-------------------------------------------------
+    &n<yellow>You collected <price><yellow> back from an auction
+    &n<aqua>-------------------------------------------------"
+  input-listener: "<yellow><request>. Please type your input in chat:"
 
 inventory-titles:
   admin-confirm-gui: "Confirm Action"
@@ -100,352 +88,352 @@ inventory-titles:
   auction-view: "Auction View"
 items:
   next-page:
-    name: "§aNext Page"
-    lore: "§7%page%/%pages%
+    name: "<green>Next Page"
+    lore: "<gray><page>/<pages>
       &n
-      &n§eRight-Click to skip!
-      &n§aClick to turn the page!"
+      &n<yellow>Right-Click to skip!
+      &n<green>Click to turn the page!"
   previous-page:
-    name: "§aPrevious Page"
-    lore: "§7%page%/%pages%
+    name: "<green>Previous Page"
+    lore: "<gray><page>/<pages>
       &n
-      &n§eRight-Click to skip!
-      &n§aClick to turn the page!"
+      &n<yellow>Right-Click to skip!
+      &n<green>Click to turn the page!"
   search:
-    name: "§aSearch"
-    lore: "§7Find Items by name, type or enchants
+    name: "<green>Search"
+    lore: "<gray>Find Items by name, type or enchants
       &n
-      &n§7Filter: %filter%
+      &n<gray>Filter: <filter>
       &n
-      &n§eRight-Click to clear!
-      &n§aClick to set filter!"
+      &n<yellow>Right-Click to clear!
+      &n<green>Click to set filter!"
   locked-slot:
-    name: "§cLocked Slot"
+    name: "<red>Locked Slot"
   refresh:
-    name: "§aRefresh"
-    lore: "§7Click to refresh the menu"
+    name: "<green>Refresh"
+    lore: "<gray>Click to refresh the menu"
   back-main-menu:
-    name: "§aMain Menu"
-    lore: "§7Click to go back!"
+    name: "<green>Main Menu"
+    lore: "<gray>Click to go back!"
   back-my-auctions:
-    name: "§aMy Auctions"
-    lore: "§7Click to go back!"
+    name: "<green>My Auctions"
+    lore: "<gray>Click to go back!"
   info:
-    name: "§aInfo"
-    lore: "§7To set up a new auction use
-      &n§7/ah sell 1000
-      &n§7while holding the item to sell in your hand.
-      &n§7The number will be the price of the item.
-      &n§7Current tax is %tax%§7.
-      &n§8 - auction house made by ElaineQheart"
+    name: "<green>Info"
+    lore: "<gray>To set up a new auction use
+      &n<gray>/ah sell 1000
+      &n<gray>while holding the item to sell in your hand.
+      &n<gray>The number will be the price of the item.
+      &n<gray>Current tax is <tax><gray>.
+      &n<dark_gray> - auction house made by ElaineQheart"
   my-auctions:
-    name: "§aMy Auctions"
-    lore: "§7Click to view your auctions!"
+    name: "<green>My Auctions"
+    lore: "<gray>Click to view your auctions!"
   sort-highest-price:
-    name: "§aSort"
+    name: "<green>Sort"
     lore: "
-      &n§b► Highest Price
-      &n§7 Lowest Price
-      &n§7 Ending Soon
-      &n§7 Alphabetical
+      &n<aqua>► Highest Price
+      &n<gray> Lowest Price
+      &n<gray> Ending Soon
+      &n<gray> Alphabetical
       &n
-      &n§eRight-Click to go backwards!
-      &n§aClick to switch sort!"
+      &n<yellow>Right-Click to go backwards!
+      &n<green>Click to switch sort!"
   sort-lowest-price:
-    name: "§aSort"
+    name: "<green>Sort"
     lore: "
-      &n§7 Highest Price
-      &n§b► Lowest Price
-      &n§7 Ending Soon
-      &n§7 Alphabetical
+      &n<gray> Highest Price
+      &n<aqua>► Lowest Price
+      &n<gray> Ending Soon
+      &n<gray> Alphabetical
       &n
-      &n§eRight-Click to go backwards!
-      &n§aClick to switch sort!"
+      &n<yellow>Right-Click to go backwards!
+      &n<green>Click to switch sort!"
   sort-ending-soon:
-    name: "§aSort"
+    name: "<green>Sort"
     lore: "
-      &n§7 Highest Price
-      &n§7 Lowest Price
-      &n§b► Ending Soon
-      &n§7 Alphabetical
+      &n<gray> Highest Price
+      &n<gray> Lowest Price
+      &n<aqua>► Ending Soon
+      &n<gray> Alphabetical
       &n
-      &n§eRight-Click to go backwards!
-      &n§aClick to switch sort!"
+      &n<yellow>Right-Click to go backwards!
+      &n<green>Click to switch sort!"
   sort-alphabetical:
-    name: "§aSort"
+    name: "<green>Sort"
     lore: "
-      &n§7 Highest Price
-      &n§7 Lowest Price
-      &n§7 Ending Soon
-      &n§b► Alphabetical
+      &n<gray> Highest Price
+      &n<gray> Lowest Price
+      &n<gray> Ending Soon
+      &n<aqua>► Alphabetical
       &n
-      &n§eRight-Click to go backwards!
-      &n§aClick to switch sort!"
+      &n<yellow>Right-Click to go backwards!
+      &n<green>Click to switch sort!"
   bin-filter-all:
-    name: "§aBIN Filter"
+    name: "<green>BIN Filter"
     lore: "
-      &n§b► Show All
-      &n§7 BIN Only
-      &n§7 Auctions Only
+      &n<aqua>► Show All
+      &n<gray> BIN Only
+      &n<gray> Auctions Only
       &n
-      &n§eRight-Click to go backwards!
-      &n§aClick to switch filter!"
+      &n<yellow>Right-Click to go backwards!
+      &n<green>Click to switch filter!"
   bin-filter-bin:
-    name: "§aBIN Filter"
+    name: "<green>BIN Filter"
     lore: "
-      &n§7 Show All
-      &n§b► BIN Only
-      &n§7 Auctions Only
+      &n<gray> Show All
+      &n<aqua>► BIN Only
+      &n<gray> Auctions Only
       &n
-      &n§eRight-Click to go backwards!
-      &n§aClick to switch filter!"
+      &n<yellow>Right-Click to go backwards!
+      &n<green>Click to switch filter!"
   bin-filter-auctions:
-    name: "§aBIN Filter"
+    name: "<green>BIN Filter"
     lore: "
-      &n§7 Show All
-      &n§7 BIN Only
-      &n§b► Auctions Only
+      &n<gray> Show All
+      &n<gray> BIN Only
+      &n<aqua>► Auctions Only
       &n
-      &n§eRight-Click to go backwards!
-      &n§aClick to switch filter!"
+      &n<yellow>Right-Click to go backwards!
+      &n<green>Click to switch filter!"
   my-sort-all:
-    name: "§aSort"
+    name: "<green>Sort"
     lore: "
-      &n§b► All Auctions
-      &n§7 Sold Items
-      &n§7 Expired Items
-      &n§7 Active Auctions
+      &n<aqua>► All Auctions
+      &n<gray> Sold Items
+      &n<gray> Expired Items
+      &n<gray> Active Auctions
       &n
-      &n§eRight-Click to go backwards!
-      &n§aClick to switch sort!"
+      &n<yellow>Right-Click to go backwards!
+      &n<green>Click to switch sort!"
   my-sort-sold:
-    name: "§aSort"
+    name: "<green>Sort"
     lore: "
-      &n§7 All Auctions
-      &n§b► Sold Items
-      &n§7 Expired Items
-      &n§7 Active Auctions
+      &n<gray> All Auctions
+      &n<aqua>► Sold Items
+      &n<gray> Expired Items
+      &n<gray> Active Auctions
       &n
-      &n§eRight-Click to go backwards!
-      &n§aClick to switch sort!"
+      &n<yellow>Right-Click to go backwards!
+      &n<green>Click to switch sort!"
   my-sort-expired:
-    name: "§aSort"
+    name: "<green>Sort"
     lore: "
-      &n§7 All Auctions
-      &n§7 Sold Items
-      &n§b► Expired Items
-      &n§7 Active Auctions
+      &n<gray> All Auctions
+      &n<gray> Sold Items
+      &n<aqua>► Expired Items
+      &n<gray> Active Auctions
       &n
-      &n§eRight-Click to go backwards!
-      &n§aClick to switch sort!"
+      &n<yellow>Right-Click to go backwards!
+      &n<green>Click to switch sort!"
   my-sort-active:
-    name: "§aSort"
+    name: "<green>Sort"
     lore: "
-      &n§7 All Auctions
-      &n§7 Sold Items
-      &n§7 Expired Items
-      &n§b► Active Auctions
+      &n<gray> All Auctions
+      &n<gray> Sold Items
+      &n<gray> Expired Items
+      &n<aqua>► Active Auctions
       &n
-      &n§eRight-Click to go backwards!
-      &n§aClick to switch sort!"
+      &n<yellow>Right-Click to go backwards!
+      &n<green>Click to switch sort!"
   cancel:
-    name: "§cCancel"
+    name: "<red>Cancel"
   collect-expired:
-    name: "§cCollect Expired Item"
+    name: "<red>Collect Expired Item"
     lore: "
-      &n§eClick to collect!"
+      &n<yellow>Click to collect!"
   cancel-auction:
-    name: "§cCancel Auction Item"
+    name: "<red>Cancel Auction Item"
     lore: "
-      &n§eClick to collect!"
+      &n<yellow>Click to collect!"
   cancel-bid-auction:
-    name: "§cCancel Auction"
+    name: "<red>Cancel Auction"
     lore: "
-      &n§7You can cancel auctions as long
-      &n§7as they have§c 0§7 bids!
+      &n<gray>You can cancel auctions as long
+      &n<gray>as they have<red> 0<gray> bids!
       &n
-      &n§eClick to cancel auction!"
+      &n<yellow>Click to cancel auction!"
   admin-info:
-    name: "§aInfo"
-    lore: "§7Click on an item to expire or delete it
-      &n§7Expired items can be collected again by the player
-      &n§7Deleted items will be removed from the auction house
-      &n§7and you will get them in your inventory"
+    name: "<green>Info"
+    lore: "<gray>Click on an item to expire or delete it
+      &n<gray>Expired items can be collected again by the player
+      &n<gray>Deleted items will be removed from the auction house
+      &n<gray>and you will get them in your inventory"
   admin-cancel-auction:
-    name: "§cCancel Auction Item"
+    name: "<red>Cancel Auction Item"
     lore: "
-      &n§eThe player won't get the item back! You will collect it!"
+      &n<yellow>The player won't get the item back! You will collect it!"
   admin-expire-auction:
-    name: "§eExpire Auction Item"
+    name: "<yellow>Expire Auction Item"
     lore: "
-      &n§eClick to make it expire!"
+      &n<yellow>Click to make it expire!"
   confirm:
-    name: "§aConfirm"
+    name: "<green>Confirm"
   deleted:
-    name: "§cCanceled Item"
+    name: "<red>Canceled Item"
   auction:
     lore:
-      default: "§8------------------
-        &n§7Seller: %seller%
-        &n§7Buy it now: %price%
+      default: "<dark_gray>------------------
+        &n<gray>Seller: <seller>
+        &n<gray>Buy it now: <price>
         &n "
-      default-starting-bid: "§8------------------
-        &n§7Seller: %seller%
-        &n§7Starting Bid: %price%
+      default-starting-bid: "<dark_gray>------------------
+        &n<gray>Seller: <seller>
+        &n<gray>Starting Bid: <price>
         &n "
-      default-bid: "§8------------------
-        &n§7Seller: %seller%
-        &n§7Bids: §a%amountOfBids% bids
+      default-bid: "<dark_gray>------------------
+        &n<gray>Seller: <seller>
+        &n<gray>Bids: <green><amountOfBids> bids
         &n 
-        &n§7Top bid: %price%
-        &n§7Bidder: %buyer%
+        &n<gray>Top bid: <price>
+        &n<gray>Bidder: <buyer>
         &n "
-      own-auction: "§aThis is your own item!
+      own-auction: "<green>This is your own item!
         &n "
-      admin-deleted: "§cDeleted by a moderator!"
-      admin-expired: "§cExpired by a moderator!"
-      admin-message: "§7Reason: %reason%"
-      expired: "§cExpired!"
-      ended: "§7Status:§a Ended!"
-      sold: "§6Sold!
-        &n§7Buyer: %buyer%"
-      partially-sold: "§6Sold: §e%sold%/%total%
-        &n§7Buyer: %buyer%&n "
-      waiting-list: "Auction starting in: %time%"
-      active: "Ends in: %time%"
-      buying-item: "§8------------------
-        &n§e§nBUYING ITEM!"
-      shulker-preview: "§f§oRight-Click to preview!"
+      admin-deleted: "<red>Deleted by a moderator!"
+      admin-expired: "<red>Expired by a moderator!"
+      admin-message: "<gray>Reason: <reason>"
+      expired: "<red>Expired!"
+      ended: "<gray>Status:<green> Ended!"
+      sold: "<gold>Sold!
+        &n<gray>Buyer: <buyer>"
+      partially-sold: "<gold>Sold: <yellow><sold>/<total>
+        &n<gray>Buyer: <buyer>&n "
+      waiting-list: "Auction starting in: <time>"
+      active: "Ends in: <time>"
+      buying-item: "<dark_gray>------------------
+        &n<yellow><underlined>BUYING ITEM!"
+      shulker-preview: "<white><italic>Right-Click to preview!"
   admin-expire-item:
-    lore: "§8------------------
-      &n§7Seller: %seller%
-      &n§7Price: %price%
+    lore: "<dark_gray>------------------
+      &n<gray>Seller: <seller>
+      &n<gray>Price: <price>
       &n
-      &n§cExpired by a moderator!
-      &n§7Reason: %reason%"
+      &n<red>Expired by a moderator!
+      &n<gray>Reason: <reason>"
   admin-delete-item:
-    lore: "§8------------------
-      &n§7Seller: %seller%
-      &n§7Price: %price%
+    lore: "<dark_gray>------------------
+      &n<gray>Seller: <seller>
+      &n<gray>Price: <price>
       &n
-      &n§cDeleted by a moderator!
-      &n§7Reason: %reason%"
+      &n<red>Deleted by a moderator!
+      &n<gray>Reason: <reason>"
   buy-item:
-    name: "§6Buy Item right now!"
+    name: "<gold>Buy Item right now!"
     lore: "
-      &n§7Price: %price%
+      &n<gray>Price: <price>
       &n
-      &n§eClick to buy!"
+      &n<yellow>Click to buy!"
   not-enough-money:
-    name: "§6Buy Item right now!"
+    name: "<gold>Buy Item right now!"
     lore: "
-      &n§7You need %price%§7 to buy this item!
+      &n<gray>You need <price><gray> to buy this item!
       &n
-      &n§cNot enough money!"
+      &n<red>Not enough money!"
   confirm-buy:
-    name: "§aConfirm"
-    lore: "§7Cost: %price%"
+    name: "<green>Confirm"
+    lore: "<gray>Cost: <price>"
   collect-sold:
-    name: "§aCollect Sold Item"
+    name: "<green>Collect Sold Item"
     lore: "
-      &n§7Value with taxes: %price%
+      &n<gray>Value with taxes: <price>
       &n
-      &n§eClick to collect!"
+      &n<yellow>Click to collect!"
   choose-item-buy-amount:
-    name: "§fChoose amount to buy!"
-    lore: "§7You can choose to buy only a few items
-      &n§7with the price being reduced accordingly
+    name: "<white>Choose amount to buy!"
+    lore: "<gray>You can choose to buy only a few items
+      &n<gray>with the price being reduced accordingly
       &n
-      &n§eClick to set!"
+      &n<yellow>Click to set!"
   loading:
     name: "loading..."
   bid-history:
-    name: "§fBid History"
-    lore: "§7Total bids: §a%amountOfBids% bids"
-    bid: "§8------------------
-      &n§7Bid: %price%
-      &n§7By: %player%
-      &n§b%time% ago"
-    more: "§8------------------
-      &n§7...%amount% more"
+    name: "<white>Bid History"
+    lore: "<gray>Total bids: <green><amountOfBids> bids"
+    bid: "<dark_gray>------------------
+      &n<gray>Bid: <price>
+      &n<gray>By: <player>
+      &n<aqua><time> ago"
+    more: "<dark_gray>------------------
+      &n<gray>...<amount> more"
   bid-explanation:
-    name: "§fBid Amount: %price%"
-    lore: "§7You need to bid at least %price%§7 to
-      &n§7hold the top bid on this auction.
+    name: "<white>Bid Amount: <price>"
+    lore: "<gray>You need to bid at least <price><gray> to
+      &n<gray>hold the top bid on this auction.
       &n
-      &n§7When the auction ends, the§e top bid
-      &n§7wins the item.
+      &n<gray>When the auction ends, the<yellow> top bid
+      &n<gray>wins the item.
       &n
-      &n§7If you do not win, you can claim your
-      &n§7bid coins back.
+      &n<gray>If you do not win, you can claim your
+      &n<gray>bid coins back.
       &n
-      &n§eClick to edit amount!"
+      &n<yellow>Click to edit amount!"
   submit-bid:
-    name: "§6Submit Bid"
+    name: "<gold>Submit Bid"
     lore: "
-      &n§7New bid: %price%
+      &n<gray>New bid: <price>
       &n
-      &n§eClick to bid!"
+      &n<yellow>Click to bid!"
   submit-another-bid:
-    name: "§6Submit Bid"
+    name: "<gold>Submit Bid"
     lore: "
-      &n§7New bid: %price%
-      &n§7Your previous bid: %price2%
+      &n<gray>New bid: <price>
+      &n<gray>Your previous bid: <price2>
       &n
-      &n§7You pay: %price3%
+      &n<gray>You pay: <price3>
       &n
-      &n§eClick to bid!"
+      &n<yellow>Click to bid!"
   cannot-afford-bid:
-    name: "§6Submit Bid"
+    name: "<gold>Submit Bid"
     lore: "
-      &n§7New Bid: %price%
+      &n<gray>New Bid: <price>
       &n
-      &n§cCannot afford bid!"
+      &n<red>Cannot afford bid!"
   top-bid:
-    name: "§6Highest Bid"
+    name: "<gold>Highest Bid"
     lore: "
-      &n§7Your bid: %price%
-      &n§7New bid: %price2%
+      &n<gray>Your bid: <price>
+      &n<gray>New bid: <price2>
       &n
-      &n§aAlready top bid!"
+      &n<green>Already top bid!"
   my-bids:
-    name: "§aManage Bids"
-    lore: "§7View and manage your bids
+    name: "<green>Manage Bids"
+    lore: "<gray>View and manage your bids
       &n
-      &n§eClick to view!"
+      &n<yellow>Click to view!"
   collect-auction:
-    name: "§6Collect Auction"
+    name: "<gold>Collect Auction"
     lore: "
-      &n§7You had the top bid for %price%
-      &n§7You may collect the item.
+      &n<gray>You had the top bid for <price>
+      &n<gray>You may collect the item.
       &n
-      &n§eClick to collect item!"
+      &n<yellow>Click to collect item!"
   collect-coins:
-    name: "§6Collect Coins"
+    name: "<gold>Collect Coins"
     lore: "
-      &n§7You did not place the top bid of this auction.
-      &n§7You may collect your bid coins back.
+      &n<gray>You did not place the top bid of this auction.
+      &n<gray>You may collect your bid coins back.
       &n
-      &n§7Top bid: %price%§7 by %player%
-      &n§7Your bid: %price2%
+      &n<gray>Top bid: <price><gray> by <player>
+      &n<gray>Your bid: <price2>
       &n
-      &n§eClick to collect coins!"
+      &n<yellow>Click to collect coins!"
   own-bid:
-    name: "§6Submit Bid"
+    name: "<gold>Submit Bid"
     lore: "
-      &n§7New bid: %price%
+      &n<gray>New bid: <price>
       &n
-      &n§aThis is your own auction!"
+      &n<green>This is your own auction!"
 
 world:
-  npc: "§6Auction Master"
+  npc: "<gold>Auction Master"
   displays:
-    line-0: "%price-trim%"
-    line-1: "§e%time%"
+    line-0: "<price-trim>"
+    line-1: "<yellow><time>"
     line-2: ""
-    line-3: "§d[CLICK]"
-    by-player: "by: %player%"
-    break-instruction: "§cTo remove the display, switch to creative mode and sneak + break the base block."
+    line-3: "<light_purple>[CLICK]"
+    by-player: "by: <player>"
+    break-instruction: "<red>To remove the display, switch to creative mode and sneak + break the base block."
 
 commands:
   ah: "ah"
@@ -486,76 +474,76 @@ commands:
   search-cancel: "cancel"
 
 command-feedback:
-  usage: "§eUsage: /ah sell <price> <amount>"
-  bid-usage: "§eTo sell an item: /ah bid <price> <amount>"
-  search-usage: "§eUsage: /ah search <item>&n§eUsage: /ah search cancel"
-  reached-max-auctions: "§eYou can only have %limit% auctions at a time"
-  no-item-in-hand: "§eYou need to hold an item in your hand to sell it"
+  usage: "<yellow>Usage: /ah sell <price> <amount>"
+  bid-usage: "<yellow>To sell an item: /ah bid <price> <amount>"
+  search-usage: "<yellow>Usage: /ah search <item>&n<yellow>Usage: /ah search cancel"
+  reached-max-auctions: "<yellow>You can only have <limit> auctions at a time"
+  no-item-in-hand: "<yellow>You need to hold an item in your hand to sell it"
   invalid-number: "That is not a valid number"
   invalid-number2: "That is not a valid price"
-  invalid-number3: "§eThat is not a valid amount of days"
-  invalid-number4: "§eThat is not a valid duration"
+  invalid-number3: "<yellow>That is not a valid amount of days"
+  invalid-number4: "<yellow>That is not a valid duration"
   invalid-number5: "Item rank number must be greater than 0"
   invalid-number6: "Invalid item rank number. Please enter a valid number"
   invalid-number7: "That is not a valid amount"
-  auction: "§eYou have put up an auction for %price%"
-  announcements-enabled: "§aAuction announcements enabled! §7You will now see when players put items on auction."
-  announcements-disabled: "§cAuction announcements disabled! §7You will no longer see when players put items on auction."
-  ban-usage: "§eUsage: /ah ban <player> <time in days> <reason>"
-  pardon-usage: "§eUsage: /ah pardon <player>"
-  player-not-found: "§eThat player is not online"
-  ban: "§b-------------------------------------------------
-    &n§e%player% was banned from the ah for %duration% days.
-    &n§rReason: %reason%
-    &n§b-------------------------------------------------"
-  pardon: "§b-------------------------------------------------
-    &n§fUnbanned %player% from the auction house
-    &n§b-------------------------------------------------"
-  no-banned-players: "§eThere are no players banned"
+  auction: "<yellow>You have put up an auction for <price>"
+  announcements-enabled: "<green>Auction announcements enabled! <gray>You will now see when players put items on auction."
+  announcements-disabled: "<red>Auction announcements disabled! <gray>You will no longer see when players put items on auction."
+  ban-usage: "<yellow>Usage: /ah ban <player> <time in days> <reason>"
+  pardon-usage: "<yellow>Usage: /ah pardon <player>"
+  player-not-found: "<yellow>That player is not online"
+  ban: "<aqua>-------------------------------------------------
+    &n<yellow><player> was banned from the ah for <duration> days.
+    &n<reset>Reason: <reason>
+    &n<aqua>-------------------------------------------------"
+  pardon: "<aqua>-------------------------------------------------
+    &n<white>Unbanned <player> from the auction house
+    &n<aqua>-------------------------------------------------"
+  no-banned-players: "<yellow>There are no players banned"
   not-banned: "That player isn't banned from the auction house"
-  reload: "§eThe auction house plugin has reloaded."
+  reload: "<yellow>The auction house plugin has reloaded."
   summon-usage: "/ah summon <entity>"
   npc-usage: "/ah summon npc facing <direction>"
   display-usage: "/ah summon display <sort type> <item rank>"
-  no-space-for-display: "§eThere is already a display here. Please remove it first."
-  no-air-space-for-display: "§eThere is not enough space to spawn a display. Please destroy the surrounding blocks first."
-  blacklist-usage: "§eUsage: /ah blacklist add <type> <text>&n§rFor <exact> and <material> you don't need <text>, but hold an item in your hand"
+  no-space-for-display: "<yellow>There is already a display here. Please remove it first."
+  no-air-space-for-display: "<yellow>There is not enough space to spawn a display. Please destroy the surrounding blocks first."
+  blacklist-usage: "<yellow>Usage: /ah blacklist add <type> <text>&n<reset>For <exact> and <material> you don't need <text>, but hold an item in your hand"
   blacklist-undo: "Successfully removed the last rule"
   blacklist-undo-error: "There are no rules"
-  blacklist-no-item-in-hand: "§eYou need to hold an item in your hand to add its properties to the blacklist"
-  blacklist-no-model: "§eYou need to hold an item in your hand with a custom \"item_model\" to add that model to the blacklist"
-  blacklist-success: "Successfully added the properties of %item%§r to the blacklist"
-  blacklist-name-success: "Successfully added \"%name%\" to the blacklist"
+  blacklist-no-item-in-hand: "<yellow>You need to hold an item in your hand to add its properties to the blacklist"
+  blacklist-no-model: "<yellow>You need to hold an item in your hand with a custom \"item_model\" to add that model to the blacklist"
+  blacklist-success: "Successfully added the properties of <item><reset> to the blacklist"
+  blacklist-name-success: "Successfully added \"<name>\" to the blacklist"
   blacklist-all: "Successfully added EVERY item to the blacklist"
-  item-blacklisted: "§cYou cannot auction this item!"
+  item-blacklisted: "<red>You cannot auction this item!"
   item-saved-to-layout-file: "Item from main hand saved in layout.yml under \"test\""
-  min-bid: "Your starting bid must be at least %price%!"
-  min-bin: "The item price must be at least %price%!"
-  max-bid: "Your starting bid can be at most %price%!"
-  max-bin: "The item price can be at most %price%!"
-  help-prefix: "§7§l--------------[ §dAuction House Help§7§l ]--------------"
+  min-bid: "Your starting bid must be at least <price>!"
+  min-bin: "The item price must be at least <price>!"
+  max-bid: "Your starting bid can be at most <price>!"
+  max-bin: "The item price can be at most <price>!"
+  help-prefix: "<gray><bold>--------------[ <light_purple>Auction House Help<gray><bold> ]--------------"
   help:
-    about: "§6/ah about:§f Displays information about the author"
-    sell: "§6/ah sell:§f Create a BIN auction with the item in your main hand"
-    bid: "§6/ah bid:§f Creates a BID auction with the item in your main hand"
-    announce: "§6/ah announce:§f Toggles auction announcements for the player"
-    admin: "§6/ah admin:§f Used to cancel or delete auctions"
-    ban: "§6/ah ban:§f Adds somebody to the banlist, making them unable to open or use the ah"
-    pardon: "§6/ah pardon:§f Removes a player from the banlist"
-    blacklist: "§6/ah blacklist:§f Adds items to the blacklist, which cannot be auctioned"
-    reload: "§6/ah reload:§f Updates any changes made to the files"
-    summon: "§6/ah summon:§f Summons the auction master npc or the item displays. Remove them by punching them in creative mode while being op"
-    test: "§6/ah test:§f Used to save the item from your main hand to the files"
-    help: "§6/ah help:§f Shows the help menu"
-    search: "§6/ah search:§f Search an item on the ah"
+    about: "<gold>/ah about:<white> Displays information about the author"
+    sell: "<gold>/ah sell:<white> Create a BIN auction with the item in your main hand"
+    bid: "<gold>/ah bid:<white> Creates a BID auction with the item in your main hand"
+    announce: "<gold>/ah announce:<white> Toggles auction announcements for the player"
+    admin: "<gold>/ah admin:<white> Used to cancel or delete auctions"
+    ban: "<gold>/ah ban:<white> Adds somebody to the banlist, making them unable to open or use the ah"
+    pardon: "<gold>/ah pardon:<white> Removes a player from the banlist"
+    blacklist: "<gold>/ah blacklist:<white> Adds items to the blacklist, which cannot be auctioned"
+    reload: "<gold>/ah reload:<white> Updates any changes made to the files"
+    summon: "<gold>/ah summon:<white> Summons the auction master npc or the item displays. Remove them by punching them in creative mode while being op"
+    test: "<gold>/ah test:<white> Used to save the item from your main hand to the files"
+    help: "<gold>/ah help:<white> Shows the help menu"
+    search: "<gold>/ah search:<white> Search an item on the ah"
 
 placeholders:
-  number: "§6%input%§r"
-  price: "%number%%currency-symbol%"
-  price-trim: "%price%"
-  currency-symbol: "§6 coins"
+  number: "<gold><input><reset>"
+  price: "<number><currency-symbol>"
+  price-trim: "<price>"
+  currency-symbol: "<gold> coins"
   format-numbers: "#,###.##"
   format-time-characters: "dhms"
-  player: "%player_name%"
-  seller: "%player_name%"
-  buyer: "%player_name%"
+  player: "<player_name>"
+  seller: "<player_name>"
+  buyer: "<player_name>"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: AuctionHouse
-version: '1.5.4'
+version: '2.0.0'
 main: me.elaineqheart.auctionHouse.AuctionHouse
 api-version: '1.21'
 folia-supported: true


### PR DESCRIPTION
This PR adds full mini message support from kyori, which I needed for my server. It replaces the old spigot API stuff with paper API and components, and swaps the placeholder system for kyori TagResolver.
 
Heads up, this is a breaking change: legacy & color codes are no longer supported.
I bumped the version to 2.0.0 to indicate the breaking changes.
 
Tested on paper 26.1.2. If spigot or legacy color support has to stay, probably dont merge this. But if anyone else needs the same thing, its here.